### PR TITLE
Removed duplicate listing for M1014.

### DIFF
--- a/ext/Shared/WeaponList.lua
+++ b/ext/Shared/WeaponList.lua
@@ -37,9 +37,6 @@ function WeaponList:__init()
 	weapon = Weapon('M1014', '', {'Weapons/Common/12gBuckshot', 'ExtendedMag'}, 'Shotgun')
 	table.insert(self._weapons, weapon);
 
-	weapon = Weapon('M1014', '', {'Weapons/Common/12gBuckshot', 'ExtendedMag'}, 'Shotgun')
-	table.insert(self._weapons, weapon);
-
 	weapon = Weapon('870M', '', {'Weapons/Remington870/U_870_Slug', 'Weapons/Remington870/U_870_ExtendedMag'}, 'Shotgun', 'Weapons/Remington870/U_870')
 	table.insert(self._weapons, weapon);
 


### PR DESCRIPTION
The duplicate entry for the M1014 was still in the weaponlist.lua. Removed it.