### PR TITLE
Auto updater change to only support stable and dev builds

### DIFF
--- a/ext/Server/__init__.lua
+++ b/ext/Server/__init__.lua
@@ -1,6 +1,5 @@
 class('FunBotServer')
 
-require('__shared/Version')
 require('__shared/Debug')
 require('__shared/Config')
 require('__shared/Constants/BotColors')

--- a/ext/Shared/Config.lua
+++ b/ext/Shared/Config.lua
@@ -12,18 +12,12 @@ Config = {
 	DebugLevel = 4, -- default: 4 (recommended)
 
 	AutoUpdater = {
-		--
 		-- Enabling the auto updater will show you a notification when a new update for fun-bots is available for download.
 		-- Please note that we do not support outdated versions.
 		Enabled = true, -- default: true (recommended)
-	
-		--
-		-- Set the release cycle on which you want to receive update notifications.
-		-- STABLE (Recommended) - Stable releases recommended on public servers.
-		-- RC - Release candidates (also known as pre-releases, snapshots, etc) are semi-tested releases.
-		-- DEV - Recommended only when testing fun-bots on a private development server.
-		--
-		ReleaseCycle = "RC" -- default: RC (recommended)
+
+		-- Do you want notifications when newer development builds are available?
+		DevBuilds = true,
 	},
 
 	--GENERAL

--- a/ext/Shared/Version.lua
+++ b/ext/Shared/Version.lua
@@ -1,2 +1,0 @@
-VERSION = '2.0.0.6'
-BRANCH = 'master'

--- a/mod.json
+++ b/mod.json
@@ -1,13 +1,13 @@
 {
 	"Name": "fun-bots",
 	"Authors": ["MajorVictory", "Bizzi","Joe-91"],
-	"Description": "Awesome AI bots for your Battlefield server",
+	"Description": "A highly customizable and configurable mod with extreme intelligent bots for your Venice Unleashed Battlefield 3 server.",
 	"URL": "https://github.com/Joe91/fun-bots",
-	"Version": "2.1.0",
+	"Version": "2.2.0",
 	"HasWebUI": true,
-	"Tags": ["fun-bots"],
+	"Tags": ["funbots", "fun-bots", "bots"],
 	"HasVeniceEXT": true,
 	"Dependencies": {
-		"veniceext": ">=1.0.8"
+		"veniceext": ">=1.1.0"
 	}
 }


### PR DESCRIPTION
V2.2.0's server update notification should only support development builds and regular releases.

This pull request resolves #119 