### PR TITLE
fix: return value of `RegistryManager:Get` method

### DIFF
--- a/ext/Client/ClientBotManager.lua
+++ b/ext/Client/ClientBotManager.lua
@@ -10,19 +10,19 @@ local m_Utilities = require('__shared/Utilities')
 local m_Logger = Logger("ClientBotManager", Debug.Client.INFO)
 
 function ClientBotManager:__init()
-	self:RegisterVars()
+    self:RegisterVars()
 end
 
 function ClientBotManager:RegisterVars()
-	self.m_RaycastTimer = 0
-	self.m_AliveTimer = 0
-	self.m_LastIndex = 0
-	self.m_Player = nil
-	self.m_ReadyToUpdate = false
-	self.m_BotBotRaycastsToDo = {}
+    self.m_RaycastTimer = 0
+    self.m_AliveTimer = 0
+    self.m_LastIndex = 0
+    self.m_Player = nil
+    self.m_ReadyToUpdate = false
+    self.m_BotBotRaycastsToDo = {}
 
-	-- inputs for change of seats (1-8)
-	self.m_LastInputLevelsPos = { 0, 0, 0, 0, 0, 0, 0, 0 }
+    -- inputs for change of seats (1-8)
+    self.m_LastInputLevelsPos = {0, 0, 0, 0, 0, 0, 0, 0}
 end
 
 -- =============================================
@@ -32,39 +32,42 @@ end
 ---VEXT Client Client:UpdateInput Event
 ---@param p_DeltaTime number
 function ClientBotManager:OnClientUpdateInput(p_DeltaTime)
-	-- TODO: find a better solution for that!!!
-	if InputManager:WentKeyDown(InputDeviceKeys.IDK_Q) then
-		--execute Vehicle Enter Detection here
-		if self.m_Player ~= nil and self.m_Player.inVehicle then
-			local s_Transform = ClientUtils:GetCameraTransform()
+    -- TODO: find a better solution for that!!!
+    if InputManager:WentKeyDown(InputDeviceKeys.IDK_Q) then
+        -- execute Vehicle Enter Detection here
+        if self.m_Player ~= nil and self.m_Player.inVehicle then
+            local s_Transform = ClientUtils:GetCameraTransform()
 
-			if s_Transform == nil then return end
+            if s_Transform == nil then
+                return
+            end
 
-			-- The freecam transform is inverted. Invert it back
-			local s_CameraForward = Vec3(s_Transform.forward.x * -1, s_Transform.forward.y * -1, s_Transform.forward.z * -1)
+            -- The freecam transform is inverted. Invert it back
+            local s_CameraForward = Vec3(s_Transform.forward.x * -1, s_Transform.forward.y * -1,
+                s_Transform.forward.z * -1)
 
-			local s_MaxEnterDistance = 50
-			local s_CastPosition = Vec3(s_Transform.trans.x + (s_CameraForward.x * s_MaxEnterDistance),
-				s_Transform.trans.y + (s_CameraForward.y * s_MaxEnterDistance),
-				s_Transform.trans.z + (s_CameraForward.z * s_MaxEnterDistance))
+            local s_MaxEnterDistance = 50
+            local s_CastPosition = Vec3(s_Transform.trans.x + (s_CameraForward.x * s_MaxEnterDistance),
+                s_Transform.trans.y + (s_CameraForward.y * s_MaxEnterDistance),
+                s_Transform.trans.z + (s_CameraForward.z * s_MaxEnterDistance))
 
-			local s_StartPosition = s_Transform.trans:Clone() + s_CameraForward * 4
+            local s_StartPosition = s_Transform.trans:Clone() + s_CameraForward * 4
 
-			local s_Raycast = RaycastManager:Raycast(s_StartPosition, s_CastPosition,
-				RayCastFlags.DontCheckWater | RayCastFlags.IsAsyncRaycast)
+            local s_Raycast = RaycastManager:Raycast(s_StartPosition, s_CastPosition,
+                RayCastFlags.DontCheckWater | RayCastFlags.IsAsyncRaycast)
 
-			if s_Raycast ~= nil and s_Raycast.rigidBody:Is("CharacterPhysicsEntity") then
-				-- find teammate at this position
-				for _, l_Player in pairs(PlayerManager:GetPlayersByTeam(self.m_Player.teamId)) do
-					if l_Player.soldier ~= nil and m_Utilities:isBot(l_Player) and
-						l_Player.soldier.worldTransform.trans:Distance(s_Raycast.position) < 2 then
-						NetEvents:SendLocal('Client:RequestEnterVehicle', l_Player.name)
-						break
-					end
-				end
-			end
-		end
-	end
+            if s_Raycast ~= nil and s_Raycast.rigidBody:Is("CharacterPhysicsEntity") then
+                -- find teammate at this position
+                for _, l_Player in pairs(PlayerManager:GetPlayersByTeam(self.m_Player.teamId)) do
+                    if l_Player.soldier ~= nil and m_Utilities:isBot(l_Player) and
+                        l_Player.soldier.worldTransform.trans:Distance(s_Raycast.position) < 2 then
+                        NetEvents:SendLocal('Client:RequestEnterVehicle', l_Player.name)
+                        break
+                    end
+                end
+            end
+        end
+    end
 end
 
 ---VEXT Client Input:PreUpdate Hook
@@ -72,314 +75,316 @@ end
 ---@param p_Cache ConceptCache
 ---@param p_DeltaTime number
 function ClientBotManager:OnInputPreUpdate(p_HookCtx, p_Cache, p_DeltaTime)
-	if self.m_Player ~= nil and self.m_Player.inVehicle then
-		for i = 1, 8 do
-			local s_Varname = "ConceptSelectPosition" .. tostring(i)
-			local s_LevelId = InputConceptIdentifiers[s_Varname]
-			local s_CurrentLevel = p_Cache:GetLevel(s_LevelId)
+    if self.m_Player ~= nil and self.m_Player.inVehicle then
+        for i = 1, 8 do
+            local s_Varname = "ConceptSelectPosition" .. tostring(i)
+            local s_LevelId = InputConceptIdentifiers[s_Varname]
+            local s_CurrentLevel = p_Cache:GetLevel(s_LevelId)
 
-			if self.m_LastInputLevelsPos[i] == 0 and s_CurrentLevel > 0 then
-				NetEvents:SendLocal('Client:RequestChangeVehicleSeat', i)
-			end
+            if self.m_LastInputLevelsPos[i] == 0 and s_CurrentLevel > 0 then
+                NetEvents:SendLocal('Client:RequestChangeVehicleSeat', i)
+            end
 
-			self.m_LastInputLevelsPos[i] = s_CurrentLevel
-		end
-	end
+            self.m_LastInputLevelsPos[i] = s_CurrentLevel
+        end
+    end
 end
 
 ---VEXT Shared Engine:Message Event
 ---@param p_Message Message
 function ClientBotManager:OnEngineMessage(p_Message)
-	if p_Message.type == MessageType.ClientLevelFinalizedMessage then
-		NetEvents:SendLocal('Client:RequestSettings')
-		self.m_ReadyToUpdate = true
-		m_Logger:Write("level loaded on Client")
-	end
+    if p_Message.type == MessageType.ClientLevelFinalizedMessage then
+        NetEvents:SendLocal('Client:RequestSettings')
+        self.m_ReadyToUpdate = true
+        m_Logger:Write("level loaded on Client")
+    end
 
-	if p_Message.type == MessageType.ClientConnectionUnloadLevelMessage or
-		p_Message.type == MessageType.ClientCharacterLocalPlayerDeletedMessage then
-		self:RegisterVars()
-	end
+    if p_Message.type == MessageType.ClientConnectionUnloadLevelMessage or p_Message.type ==
+        MessageType.ClientCharacterLocalPlayerDeletedMessage then
+        self:RegisterVars()
+    end
 end
 
 function ClientBotManager:DoRaycast(p_Pos1, p_Pos2, p_InObjectPos1, p_InObjectPos2)
-	if Registry.COMMON.USE_COLLITION_RAYCASTS then
-		local s_MaxHits = 1
+    if Registry.COMMON.USE_COLLISION_RAYCASTS then
+        local s_MaxHits = 1
 
-		if p_InObjectPos1 then
-			s_MaxHits = s_MaxHits + 1
-		end
+        if p_InObjectPos1 then
+            s_MaxHits = s_MaxHits + 1
+        end
 
-		if p_InObjectPos2 then
-			s_MaxHits = s_MaxHits + 1
-		end
+        if p_InObjectPos2 then
+            s_MaxHits = s_MaxHits + 1
+        end
 
-		local s_MaterialFlags = 0 --MaterialFlags.MfPenetrable | MaterialFlags.MfClientDestructible | MaterialFlags.MfBashable | MaterialFlags.MfSeeThrough | MaterialFlags.MfNoCollisionResponse | MaterialFlags.MfNoCollisionResponseCombined
-		local s_RaycastFlags = RayCastFlags.DontCheckWater | RayCastFlags.DontCheckCharacter
+        local s_MaterialFlags = 0 -- MaterialFlags.MfPenetrable | MaterialFlags.MfClientDestructible | MaterialFlags.MfBashable | MaterialFlags.MfSeeThrough | MaterialFlags.MfNoCollisionResponse | MaterialFlags.MfNoCollisionResponseCombined
+        local s_RaycastFlags = RayCastFlags.DontCheckWater | RayCastFlags.DontCheckCharacter
 
-		local s_RayHits = RaycastManager:CollisionRaycast(p_Pos1, p_Pos2, s_MaxHits, s_MaterialFlags, s_RaycastFlags)
+        local s_RayHits = RaycastManager:CollisionRaycast(p_Pos1, p_Pos2, s_MaxHits, s_MaterialFlags, s_RaycastFlags)
 
-		if s_RayHits ~= nil and #s_RayHits < s_MaxHits then
-			return true
-		else
-			return false
-		end
-	else
-		if p_InObjectPos1 or p_InObjectPos2 then
-			local s_DeltaPos = p_Pos2 - p_Pos1
-			s_DeltaPos = s_DeltaPos:Normalize()
+        if s_RayHits ~= nil and #s_RayHits < s_MaxHits then
+            return true
+        else
+            return false
+        end
+    else
+        if p_InObjectPos1 or p_InObjectPos2 then
+            local s_DeltaPos = p_Pos2 - p_Pos1
+            s_DeltaPos = s_DeltaPos:Normalize()
 
-			if p_InObjectPos1 then -- Start Raycast outside of vehicle?
-				p_Pos1 = p_Pos1 + (s_DeltaPos * 3.2)
-			end
+            if p_InObjectPos1 then -- Start Raycast outside of vehicle?
+                p_Pos1 = p_Pos1 + (s_DeltaPos * 3.2)
+            end
 
-			if p_InObjectPos2 then
-				p_Pos2 = p_Pos2 - (s_DeltaPos * 3.2)
-			end
-		end
+            if p_InObjectPos2 then
+                p_Pos2 = p_Pos2 - (s_DeltaPos * 3.2)
+            end
+        end
 
-		local s_RaycastFlags = RayCastFlags.DontCheckWater | RayCastFlags.DontCheckCharacter | RayCastFlags.IsAsyncRaycast
-		local s_Raycast = RaycastManager:Raycast(p_Pos1, p_Pos2, s_RaycastFlags)
+        local s_RaycastFlags = RayCastFlags.DontCheckWater | RayCastFlags.DontCheckCharacter |
+                                   RayCastFlags.IsAsyncRaycast
+        local s_Raycast = RaycastManager:Raycast(p_Pos1, p_Pos2, s_RaycastFlags)
 
-		if s_Raycast == nil or s_Raycast.rigidBody == nil then
-			return true
-		else
-			return false
-		end
-	end
+        if s_Raycast == nil or s_Raycast.rigidBody == nil then
+            return true
+        else
+            return false
+        end
+    end
 end
 
 function ClientBotManager:SendRaycastResults(p_RaycastResultsToSend)
-	NetEvents:SendLocal("Botmanager:RaycastResults", p_RaycastResultsToSend)
+    NetEvents:SendLocal("Botmanager:RaycastResults", p_RaycastResultsToSend)
 end
 
 ---VEXT Shared UpdateManager:Update Event
 ---@param p_DeltaTime number
 ---@param p_UpdatePass UpdatePass|integer
 function ClientBotManager:OnUpdateManagerUpdate(p_DeltaTime, p_UpdatePass)
-	if p_UpdatePass ~= UpdatePass.UpdatePass_PreSim or not self.m_ReadyToUpdate then --UpdatePass_PreSim UpdatePass_PreFrame
-		return
-	end
+    if p_UpdatePass ~= UpdatePass.UpdatePass_PreSim or not self.m_ReadyToUpdate then -- UpdatePass_PreSim UpdatePass_PreFrame
+        return
+    end
 
-	local s_RaycastResultsToSend = {}
+    local s_RaycastResultsToSend = {}
 
-	self.m_RaycastTimer = self.m_RaycastTimer + p_DeltaTime
-	local s_SkipEnemyCheck = not Config.BotsAttackPlayers or
-		(self.m_RaycastTimer < Registry.GAME_RAYCASTING.RAYCAST_INTERVAL_ENEMY_CHECK)
+    self.m_RaycastTimer = self.m_RaycastTimer + p_DeltaTime
+    local s_SkipEnemyCheck = not Config.BotsAttackPlayers or
+                                 (self.m_RaycastTimer < Registry.GAME_RAYCASTING.RAYCAST_INTERVAL_ENEMY_CHECK)
 
-	-- check bot-bot attack
-	if #self.m_BotBotRaycastsToDo > 0 then
-		local s_MaxRaycastsBotBot = Registry.GAME_RAYCASTING.MAX_RAYCASTS_PER_PLAYER_PER_CYCLE
+    -- check bot-bot attack
+    if #self.m_BotBotRaycastsToDo > 0 then
+        local s_MaxRaycastsBotBot = Registry.GAME_RAYCASTING.MAX_RAYCASTS_PER_PLAYER_PER_CYCLE
 
-		if not s_SkipEnemyCheck then
-			s_MaxRaycastsBotBot = s_MaxRaycastsBotBot - 1
-		end
+        if not s_SkipEnemyCheck then
+            s_MaxRaycastsBotBot = s_MaxRaycastsBotBot - 1
+        end
 
-		local s_RaycastEntriesDone = 0
+        local s_RaycastEntriesDone = 0
 
-		for i = 1, s_MaxRaycastsBotBot do
-			if (#self.m_BotBotRaycastsToDo > 0) then
-				local s_RaycastCheckEntry = table.remove(self.m_BotBotRaycastsToDo, 1)
-				s_RaycastEntriesDone = s_RaycastEntriesDone + 1
-				local s_Bot1 = PlayerManager:GetPlayerByName(s_RaycastCheckEntry.Bot1)
-				local s_Bot2 = PlayerManager:GetPlayerByName(s_RaycastCheckEntry.Bot2)
+        for i = 1, s_MaxRaycastsBotBot do
+            if (#self.m_BotBotRaycastsToDo > 0) then
+                local s_RaycastCheckEntry = table.remove(self.m_BotBotRaycastsToDo, 1)
+                s_RaycastEntriesDone = s_RaycastEntriesDone + 1
+                local s_Bot1 = PlayerManager:GetPlayerByName(s_RaycastCheckEntry.Bot1)
+                local s_Bot2 = PlayerManager:GetPlayerByName(s_RaycastCheckEntry.Bot2)
 
-				if s_Bot1 and s_Bot2 and s_Bot1.soldier and s_Bot2.soldier then
-					local s_StartPos = nil
-					local s_EndPos = nil
-					if s_RaycastCheckEntry.Bot1InVehicle then
-						s_StartPos = s_Bot1.controlledControllable.transform.trans:Clone()
-					else
-						s_StartPos = s_Bot1.soldier.worldTransform.trans:Clone()
-					end
-					s_StartPos.y = s_StartPos.y + 1.4
+                if s_Bot1 and s_Bot2 and s_Bot1.soldier and s_Bot2.soldier then
+                    local s_StartPos = nil
+                    local s_EndPos = nil
+                    if s_RaycastCheckEntry.Bot1InVehicle then
+                        s_StartPos = s_Bot1.controlledControllable.transform.trans:Clone()
+                    else
+                        s_StartPos = s_Bot1.soldier.worldTransform.trans:Clone()
+                    end
+                    s_StartPos.y = s_StartPos.y + 1.4
 
-					if s_RaycastCheckEntry.Bot2InVehicle then
-						s_EndPos = s_Bot2.controlledControllable.transform.trans:Clone()
-					else
-						s_EndPos = s_Bot2.soldier.worldTransform.trans:Clone()
-					end
-					s_EndPos.y = s_EndPos.y + 1.4
-					if self:DoRaycast(s_StartPos, s_EndPos, s_RaycastCheckEntry.Bot1InVehicle, s_RaycastCheckEntry.Bot2InVehicle) then
-						table.insert(s_RaycastResultsToSend, {
-							Mode = "ShootAtBot",
-							Bot1 = s_RaycastCheckEntry.Bot1,
-							Bot2 = s_RaycastCheckEntry.Bot2,
-							IgnoreYaw = false,
-						})
-					end
-				end
-			end
-		end
+                    if s_RaycastCheckEntry.Bot2InVehicle then
+                        s_EndPos = s_Bot2.controlledControllable.transform.trans:Clone()
+                    else
+                        s_EndPos = s_Bot2.soldier.worldTransform.trans:Clone()
+                    end
+                    s_EndPos.y = s_EndPos.y + 1.4
+                    if self:DoRaycast(s_StartPos, s_EndPos, s_RaycastCheckEntry.Bot1InVehicle,
+                        s_RaycastCheckEntry.Bot2InVehicle) then
+                        table.insert(s_RaycastResultsToSend, {
+                            Mode = "ShootAtBot",
+                            Bot1 = s_RaycastCheckEntry.Bot1,
+                            Bot2 = s_RaycastCheckEntry.Bot2,
+                            IgnoreYaw = false
+                        })
+                    end
+                end
+            end
+        end
 
-		-- check for too many entries
-		if #self.m_BotBotRaycastsToDo > 20 then
-			m_Logger:Write("More Raycasts than doable")
-			self.m_BotBotRaycastsToDo = {}
-		end
-	end
+        -- check for too many entries
+        if #self.m_BotBotRaycastsToDo > 20 then
+            m_Logger:Write("More Raycasts than doable")
+            self.m_BotBotRaycastsToDo = {}
+        end
+    end
 
-	if self.m_Player == nil then
-		self.m_Player = PlayerManager:GetLocalPlayer()
+    if self.m_Player == nil then
+        self.m_Player = PlayerManager:GetLocalPlayer()
 
-		if self.m_Player == nil then
-			self:SendRaycastResults(s_RaycastResultsToSend)
-			return
-		end
-	end
+        if self.m_Player == nil then
+            self:SendRaycastResults(s_RaycastResultsToSend)
+            return
+        end
+    end
 
-	if s_SkipEnemyCheck then
-		self:SendRaycastResults(s_RaycastResultsToSend)
-		return
-	end
+    if s_SkipEnemyCheck then
+        self:SendRaycastResults(s_RaycastResultsToSend)
+        return
+    end
 
-	self.m_RaycastTimer = 0
-	local s_CheckCount = 0
+    self.m_RaycastTimer = 0
+    local s_CheckCount = 0
 
-	if self.m_Player.soldier ~= nil then -- alive. Check for enemy bots
-		if self.m_AliveTimer < Registry.CLIENT.SPAWN_PROTECTION then -- wait 2s (spawn-protection)
-			self.m_AliveTimer = self.m_AliveTimer + p_DeltaTime
-			self:SendRaycastResults(s_RaycastResultsToSend)
-			return
-		end
+    if self.m_Player.soldier ~= nil then -- alive. Check for enemy bots
+        if self.m_AliveTimer < Registry.CLIENT.SPAWN_PROTECTION then -- wait 2s (spawn-protection)
+            self.m_AliveTimer = self.m_AliveTimer + p_DeltaTime
+            self:SendRaycastResults(s_RaycastResultsToSend)
+            return
+        end
 
-		local s_EnemyPlayers = {}
+        local s_EnemyPlayers = {}
 
-		for _, l_Player in pairs(PlayerManager:GetPlayers()) do
-			if l_Player.teamId ~= self.m_Player.teamId and self.m_Player.teamId ~= 0 then -- don't let bots attack spectators
-				table.insert(s_EnemyPlayers, l_Player)
-			end
-		end
+        for _, l_Player in pairs(PlayerManager:GetPlayers()) do
+            if l_Player.teamId ~= self.m_Player.teamId and self.m_Player.teamId ~= 0 then -- don't let bots attack spectators
+                table.insert(s_EnemyPlayers, l_Player)
+            end
+        end
 
-		if self.m_LastIndex >= #s_EnemyPlayers then
-			self.m_LastIndex = 0
-		end
+        if self.m_LastIndex >= #s_EnemyPlayers then
+            self.m_LastIndex = 0
+        end
 
-		-- check for clear view
-		local s_PlayerPosition = Vec3()
-		if self.m_Player.inVehicle then
-			s_PlayerPosition = self.m_Player.controlledControllable.transform.trans:Clone()
-			s_PlayerPosition.y = s_PlayerPosition.y + 1.4
-		else
-			s_PlayerPosition = ClientUtils:GetCameraTransform().trans:Clone() --player.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(player, false)
-		end
-		for i = 0, #s_EnemyPlayers - 1 do
-			local s_Index = (self.m_LastIndex + i) % #s_EnemyPlayers + 1
-			local s_Bot = s_EnemyPlayers[s_Index]
+        -- check for clear view
+        local s_PlayerPosition = Vec3()
+        if self.m_Player.inVehicle then
+            s_PlayerPosition = self.m_Player.controlledControllable.transform.trans:Clone()
+            s_PlayerPosition.y = s_PlayerPosition.y + 1.4
+        else
+            s_PlayerPosition = ClientUtils:GetCameraTransform().trans:Clone() -- player.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(player, false)
+        end
+        for i = 0, #s_EnemyPlayers - 1 do
+            local s_Index = (self.m_LastIndex + i) % #s_EnemyPlayers + 1
+            local s_Bot = s_EnemyPlayers[s_Index]
 
-			if s_Bot == nil or s_Bot.onlineId ~= 0 or s_Bot.soldier == nil then
-				goto continue_enemy_loop
-			end
+            if s_Bot == nil or s_Bot.onlineId ~= 0 or s_Bot.soldier == nil then
+                goto continue_enemy_loop
+            end
 
-			-- find direction of Bot
-			local s_TargetPos = Vec3()
-			if s_Bot.inVehicle then
-				s_TargetPos = s_Bot.controlledControllable.transform.trans:Clone()
-				s_TargetPos.y = s_TargetPos.y + 1.4
-			else
-				s_TargetPos = s_Bot.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(s_Bot, false, false)
-			end
-			local s_Distance = s_PlayerPosition:Distance(s_TargetPos)
+            -- find direction of Bot
+            local s_TargetPos = Vec3()
+            if s_Bot.inVehicle then
+                s_TargetPos = s_Bot.controlledControllable.transform.trans:Clone()
+                s_TargetPos.y = s_TargetPos.y + 1.4
+            else
+                s_TargetPos = s_Bot.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(s_Bot, false, false)
+            end
+            local s_Distance = s_PlayerPosition:Distance(s_TargetPos)
 
-			s_CheckCount = s_CheckCount + 1
+            s_CheckCount = s_CheckCount + 1
 
-			if (s_Distance < Config.MaxShootDistanceSniper) or
-				(s_Bot.inVehicle and (s_Distance < Config.MaxShootDistanceVehicles)) then
-				if self:DoRaycast(s_PlayerPosition, s_TargetPos, self.m_Player.inVehicle, s_Bot.inVehicle) then
-					-- we found a valid bot in Sight (either no hit, or player-hit). Signal Server with players
-					local s_IgnoreYaw = false
+            if (s_Distance < Config.MaxShootDistanceSniper) or
+                (s_Bot.inVehicle and (s_Distance < Config.MaxShootDistanceVehicles)) then
+                if self:DoRaycast(s_PlayerPosition, s_TargetPos, self.m_Player.inVehicle, s_Bot.inVehicle) then
+                    -- we found a valid bot in Sight (either no hit, or player-hit). Signal Server with players
+                    local s_IgnoreYaw = false
 
-					if s_Distance < Config.DistanceForDirectAttack then
-						s_IgnoreYaw = true -- shoot, because you are near
-					end
+                    if s_Distance < Config.DistanceForDirectAttack then
+                        s_IgnoreYaw = true -- shoot, because you are near
+                    end
 
-					table.insert(s_RaycastResultsToSend, {
-						Mode = "ShootAtPlayer",
-						Bot1 = s_Bot.name,
-						Bot2 = "",
-						IgnoreYaw = s_IgnoreYaw,
-					})
-				end
+                    table.insert(s_RaycastResultsToSend, {
+                        Mode = "ShootAtPlayer",
+                        Bot1 = s_Bot.name,
+                        Bot2 = "",
+                        IgnoreYaw = s_IgnoreYaw
+                    })
+                end
 
-				self.m_LastIndex = s_Index
-				self:SendRaycastResults(s_RaycastResultsToSend)
-				return --only one raycast per cycle
-			end
+                self.m_LastIndex = s_Index
+                self:SendRaycastResults(s_RaycastResultsToSend)
+                return -- only one raycast per cycle
+            end
 
-			if s_CheckCount >= Registry.CLIENT.MAX_CHECKS_PER_CYCLE then
-				self.m_LastIndex = s_Index
-				self:SendRaycastResults(s_RaycastResultsToSend)
-				return
-			end
+            if s_CheckCount >= Registry.CLIENT.MAX_CHECKS_PER_CYCLE then
+                self.m_LastIndex = s_Index
+                self:SendRaycastResults(s_RaycastResultsToSend)
+                return
+            end
 
-			::continue_enemy_loop::
-		end
-	elseif self.m_Player.corpse ~= nil and not self.m_Player.corpse.isDead then -- dead. check for revive botsAttackBots
-		self.m_AliveTimer = 0.5 --add a little delay
-		local s_TeamMates = PlayerManager:GetPlayersByTeam(self.m_Player.teamId)
+            ::continue_enemy_loop::
+        end
+    elseif self.m_Player.corpse ~= nil and not self.m_Player.corpse.isDead then -- dead. check for revive botsAttackBots
+        self.m_AliveTimer = 0.5 -- add a little delay
+        local s_TeamMates = PlayerManager:GetPlayersByTeam(self.m_Player.teamId)
 
-		if self.m_LastIndex >= #s_TeamMates then
-			self.m_LastIndex = 0
-		end
+        if self.m_LastIndex >= #s_TeamMates then
+            self.m_LastIndex = 0
+        end
 
-		for i = 0, #s_TeamMates - 1 do
-			local s_Index = (self.m_LastIndex + i) % #s_TeamMates + 1
-			local s_Bot = s_TeamMates[s_Index]
+        for i = 0, #s_TeamMates - 1 do
+            local s_Index = (self.m_LastIndex + i) % #s_TeamMates + 1
+            local s_Bot = s_TeamMates[s_Index]
 
-			if s_Bot == nil or s_Bot.onlineId ~= 0 or s_Bot.soldier == nil or s_Bot.inVehicle then
-				goto continue_teamMate_loop
-			end
+            if s_Bot == nil or s_Bot.onlineId ~= 0 or s_Bot.soldier == nil or s_Bot.inVehicle then
+                goto continue_teamMate_loop
+            end
 
-			-- check for clear view
-			local s_PlayerPosition = self.m_Player.corpse.worldTransform.trans:Clone()
-			s_PlayerPosition.y = s_PlayerPosition.y + 0.4
+            -- check for clear view
+            local s_PlayerPosition = self.m_Player.corpse.worldTransform.trans:Clone()
+            s_PlayerPosition.y = s_PlayerPosition.y + 0.4
 
-			-- find direction of Bot
-			local s_Target = s_Bot.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(s_Bot, false, false)
-			local s_Distance = s_PlayerPosition:Distance(s_Bot.soldier.worldTransform.trans)
+            -- find direction of Bot
+            local s_Target = s_Bot.soldier.worldTransform.trans:Clone() + m_Utilities:getCameraPos(s_Bot, false, false)
+            local s_Distance = s_PlayerPosition:Distance(s_Bot.soldier.worldTransform.trans)
 
-			s_CheckCount = s_CheckCount + 1
+            s_CheckCount = s_CheckCount + 1
 
-			if s_Distance < Registry.CLIENT.REVIVE_DISTANCE then -- TODO: use config var for this
-				self.m_LastIndex = s_Index
+            if s_Distance < Registry.CLIENT.REVIVE_DISTANCE then -- TODO: use config var for this
+                self.m_LastIndex = s_Index
 
-				if self:DoRaycast(s_PlayerPosition, s_Target, false, false) then
-					-- we found a valid bot in Sight (either no hit, or player-hit). Signal Server with players
-					table.insert(s_RaycastResultsToSend, {
-						Mode = "RevivePlayer",
-						Bot1 = s_Bot.name,
-						Bot2 = "",
-						IgnoreYaw = false,
-					})
-				end
+                if self:DoRaycast(s_PlayerPosition, s_Target, false, false) then
+                    -- we found a valid bot in Sight (either no hit, or player-hit). Signal Server with players
+                    table.insert(s_RaycastResultsToSend, {
+                        Mode = "RevivePlayer",
+                        Bot1 = s_Bot.name,
+                        Bot2 = "",
+                        IgnoreYaw = false
+                    })
+                end
 
-				self:SendRaycastResults(s_RaycastResultsToSend)
-				return -- only one raycast per cycle
-			end
+                self:SendRaycastResults(s_RaycastResultsToSend)
+                return -- only one raycast per cycle
+            end
 
-			if s_CheckCount >= Registry.CLIENT.MAX_CHECKS_PER_CYCLE then
-				self.m_LastIndex = s_Index
-				self:SendRaycastResults(s_RaycastResultsToSend)
-				return
-			end
+            if s_CheckCount >= Registry.CLIENT.MAX_CHECKS_PER_CYCLE then
+                self.m_LastIndex = s_Index
+                self:SendRaycastResults(s_RaycastResultsToSend)
+                return
+            end
 
-			::continue_teamMate_loop::
-		end
-	else
-		self.m_AliveTimer = 0 --add a little delay after spawn
-	end
+            ::continue_teamMate_loop::
+        end
+    else
+        self.m_AliveTimer = 0 -- add a little delay after spawn
+    end
 
-	self:SendRaycastResults(s_RaycastResultsToSend)
+    self:SendRaycastResults(s_RaycastResultsToSend)
 end
 
 ---VEXT Shared Extension:Unloading Event
 function ClientBotManager:OnExtensionUnloading()
-	self:RegisterVars()
+    self:RegisterVars()
 end
 
 ---VEXT Shared Level:Destroy Event
 function ClientBotManager:OnLevelDestroy()
-	self:RegisterVars()
+    self:RegisterVars()
 end
 
 -- =============================================
@@ -387,23 +392,23 @@ end
 -- =============================================
 
 function ClientBotManager:OnWriteClientSettings(p_NewConfig, p_UpdateWeaponSets)
-	for l_Key, l_Value in pairs(p_NewConfig) do
-		Config[l_Key] = l_Value
-	end
+    for l_Key, l_Value in pairs(p_NewConfig) do
+        Config[l_Key] = l_Value
+    end
 
-	m_Logger:Write("write settings")
+    m_Logger:Write("write settings")
 
-	if p_UpdateWeaponSets then
-		m_WeaponList:UpdateWeaponList()
-	end
+    if p_UpdateWeaponSets then
+        m_WeaponList:UpdateWeaponList()
+    end
 
-	self.m_Player = PlayerManager:GetLocalPlayer()
+    self.m_Player = PlayerManager:GetLocalPlayer()
 end
 
 function ClientBotManager:CheckForBotBotAttack(p_RaycastData)
-	for _, l_RaycastEntry in pairs(p_RaycastData) do
-		table.insert(self.m_BotBotRaycastsToDo, l_RaycastEntry)
-	end
+    for _, l_RaycastEntry in pairs(p_RaycastData) do
+        table.insert(self.m_BotBotRaycastsToDo, l_RaycastEntry)
+    end
 end
 
 -- =============================================
@@ -411,8 +416,8 @@ end
 -- =============================================
 
 if g_ClientBotManager == nil then
-	---@type ClientBotManager
-	g_ClientBotManager = ClientBotManager()
+    ---@type ClientBotManager
+    g_ClientBotManager = ClientBotManager()
 end
 
 return g_ClientBotManager

--- a/ext/Shared/ArrayMap.lua
+++ b/ext/Shared/ArrayMap.lua
@@ -1,67 +1,59 @@
 ---@class ArrayMap
 ---@overload fun():ArrayMap
-ArrayMap = class 'ArrayMap'
+ArrayMap = class('ArrayMap')
 
 function ArrayMap:__init()
-	self._entries = {}
+    self._Entries = {}
 end
 
 function ArrayMap:add(p_Value)
-	table.insert(self._entries, p_Value)
+    table.insert(self._Entries, p_Value)
 end
 
 function ArrayMap:deleteByIndex(p_Index)
-	table.remove(self._entries, p_Index)
+    table.remove(self._Entries, p_Index)
 end
 
 function ArrayMap:exists(p_Value)
-	local s_Index = {}
+    for l_Key, l_Data in pairs(self._Entries) do
+        if p_Value == l_Data then
+            return true
+        end
+    end
 
-	for l_Key, l_Data in pairs(self._entries) do
-		s_Index[l_Data] = l_Key
-	end
-
-	if s_Index[p_Value] ~= nil then
-		return true
-	end
-
-	return false
+    return false
 end
 
 function ArrayMap:delete(p_Value)
-	local s_Index = {}
-
-	for l_Key, l_Data in pairs(self._entries) do
-		s_Index[l_Data] = l_Key
-	end
-
-	if s_Index[p_Value] ~= nil then
-		self:deleteByIndex(s_Index[p_Value])
-	end
+    for l_Key, l_Data in pairs(self._Entries) do
+        if p_Value == l_Data then
+            self:deleteByIndex(l_Key)
+        end
+    end
 end
 
 function ArrayMap:isEmpty()
-	return self:count() == 0
+    return self:count() == 0
 end
 
 function ArrayMap:clear()
-	self._entries = {}
+    self._Entries = {}
 end
 
 function ArrayMap:count()
-	return #self._entries
+    return #self._Entries
 end
 
 function ArrayMap:getEntries()
-	return self._entries
+    return self._Entries
 end
 
 function ArrayMap:join(p_Character)
-	return table.concat(self._entries, p_Character)
+    return table.concat(self._Entries, p_Character)
 end
 
 function ArrayMap:_tostring()
-	return '[ArrayList Count=' .. self:count() .. ', ' .. json.encode(self._entries) .. ']'
+    return '[ArrayList Count=' .. self:count() .. ', ' .. json.encode(self._Entries) .. ']'
 end
 
 return ArrayMap

--- a/ext/Shared/Registry/Registry.lua
+++ b/ext/Shared/Registry/Registry.lua
@@ -10,159 +10,159 @@ require('__shared/Constants/VersionType')
 ]]
 ---@class Registry
 Registry = {
-	COMMON = {
-		-- token Bots are marked with. Can also be " " or "". If it's "" players with names of the botlist can't join!
-		BOT_TOKEN = "BOT_",
-		-- allow players to use Bot-Names
-		ALLOW_PLAYER_BOT_NAMES = true,
-		-- collition-raycasts are an other type of raycast. Sadly not working atm...
-		USE_COLLITION_RAYCASTS = false,
-		-- distance commands are heard by bots
-		COMMAND_DISTANCE = 20,
-		-- use load of Bundle to fix Bug of weapons disapearing (thanks to Lesley!) !!! THIS MIGHT CAUSE CRASHES !!!
-		USE_LOAD_BUNDLE_BUGFIX = false,
-		-- valid keys can be found here: https://docs.veniceunleashed.net/vext/ref/fb/inputdevicekeys/
-		BOT_COMMAND_KEY = InputDeviceKeys.IDK_LeftAlt,
-	},
-	-- Version and Release related variables
-	-- Variables related to the current build version, version and the type of version.
-	-- We use semantic versioning. Please see: https://semver.org
-	VERSION = {
-		-- Major version
-		VERSION_MAJ = 2,
-		-- Minor version
-		VERSION_MIN = 7,
-		-- Patch version
-		VERSION_PATCH = 0,
-		-- Additional label for pre-releases and build meta data
-		VERSION_LABEL = "dev3",
-		-- Current version type of this build
-		VERSION_TYPE = VersionType.DevBuild,
-		-- The Version used for the Update-Check
-		UPDATE_CHANNEL = VersionType.DevBuild,
-		-- prints current version in console
-		CLIENT_SHOW_VERSION_ON_JOIN = false,
-	},
+    COMMON = {
+        -- token Bots are marked with. Can also be " " or "". If it's "" players with names of the botlist can't join!
+        BOT_TOKEN = "BOT_",
+        -- allow players to use Bot-Names
+        ALLOW_PLAYER_BOT_NAMES = true,
+        -- collision-raycasts are an other type of raycast. Sadly not working at the moment...
+        USE_COLLISION_RAYCASTS = false,
+        -- distance commands are heard by bots
+        COMMAND_DISTANCE = 20,
+        -- use load of Bundle to fix Bug of weapons disappearing (thanks to Lesley!) !!! THIS MIGHT CAUSE CRASHES !!!
+        USE_LOAD_BUNDLE_BUGFIX = false,
+        -- valid keys can be found here: https://docs.veniceunleashed.net/vext/ref/fb/inputdevicekeys/
+        BOT_COMMAND_KEY = InputDeviceKeys.IDK_LeftAlt
+    },
+    -- Version and Release related variables
+    -- Variables related to the current build version, version and the type of version.
+    -- We use semantic versioning. Please see: https://semver.org
+    VERSION = {
+        -- Major version
+        VERSION_MAJ = 2,
+        -- Minor version
+        VERSION_MIN = 7,
+        -- Patch version
+        VERSION_PATCH = 0,
+        -- Additional label for pre-releases and build meta data
+        VERSION_LABEL = "dev3",
+        -- Current version type of this build
+        VERSION_TYPE = VersionType.DevBuild,
+        -- The Version used for the Update-Check
+        UPDATE_CHANNEL = VersionType.DevBuild,
+        -- prints current version in console
+        CLIENT_SHOW_VERSION_ON_JOIN = false
+    },
 
-	-- some Client Variables
-	CLIENT = {
-		-- distance a bot tries to revive a player
-		REVIVE_DISTANCE = 30.0,
-		-- the number of attack-checks done per cycle
-		MAX_CHECKS_PER_CYCLE = 10,
-		-- time bots will not attack a player when spawned
-		SPAWN_PROTECTION = 1.5,
-	},
+    -- some Client Variables
+    CLIENT = {
+        -- distance a bot tries to revive a player
+        REVIVE_DISTANCE = 30.0,
+        -- the number of attack-checks done per cycle
+        MAX_CHECKS_PER_CYCLE = 10,
+        -- time bots will not attack a player when spawned
+        SPAWN_PROTECTION = 1.5
+    },
 
-	-- Variables related to raycasting
-	GAME_RAYCASTING = {
-		MAX_RAYCASTS_PER_PLAYER_PER_CYCLE = 3,
-		-- Max Raycasts for Bot-Bot Attack per player and cycle. Needs to be smaller than max_raycats
-		MAX_RAYCASTS_PER_PLAYER_BOT_BOT = 2,
-		-- how often get the nodes calculated
-		UPDATE_INTERVAL_NODEEDITOR = 0.03,
-		-- Raycast Interval of client for different raycasts
-		RAYCAST_INTERVAL_ENEMY_CHECK = 0.03,
-		-- how often are the connections for a bot-bot-attack checked
-		BOT_BOT_CHECK_INTERVAL = 0.05,
-		-- max checks per cycle
-		BOT_BOT_MAX_CHECKS = 30
-	},
+    -- Variables related to raycasting
+    GAME_RAYCASTING = {
+        MAX_RAYCASTS_PER_PLAYER_PER_CYCLE = 3,
+        -- Max Raycasts for Bot-Bot Attack per player and cycle. Needs to be smaller than max_raycats
+        MAX_RAYCASTS_PER_PLAYER_BOT_BOT = 2,
+        -- how often get the nodes calculated
+        UPDATE_INTERVAL_NODEEDITOR = 0.03,
+        -- Raycast Interval of client for different raycasts
+        RAYCAST_INTERVAL_ENEMY_CHECK = 0.03,
+        -- how often are the connections for a bot-bot-attack checked
+        BOT_BOT_CHECK_INTERVAL = 0.05,
+        -- max checks per cycle
+        BOT_BOT_MAX_CHECKS = 30
+    },
 
-	-- Variables used by the Gamedirector-context
-	GAME_DIRECTOR = {
-		UPDATE_OBJECTIVES_CYCLE = 1.5,
-		-- Time after a mcom is considered destroyed
-		MCOMS_CHECK_CYCLE = 26.5,
-		-- Zone is 30 s. 10 Seconds without damage
-		ZONE_CHECK_CYCLE = 20.0,
-		-- max bots per objective
-		MAX_ASSIGNED_LIMIT = 16,
-		-- after finding no valid path for that many crossings, a bot is killed (Rush only)
-		KILL_ON_INVALID_PATH_CROSSINGS = 10,
-		-- increments of nodes to search best patch with
-		NODE_SEARCH_INCREMENTS = 10,
-	},
+    -- Variables used by the Gamedirector-context
+    GAME_DIRECTOR = {
+        UPDATE_OBJECTIVES_CYCLE = 1.5,
+        -- Time after a mcom is considered destroyed
+        MCOMS_CHECK_CYCLE = 26.5,
+        -- Zone is 30 s. 10 Seconds without damage
+        ZONE_CHECK_CYCLE = 20.0,
+        -- max bots per objective
+        MAX_ASSIGNED_LIMIT = 16,
+        -- after finding no valid path for that many crossings, a bot is killed (Rush only)
+        KILL_ON_INVALID_PATH_CROSSINGS = 10,
+        -- increments of nodes to search best patch with
+        NODE_SEARCH_INCREMENTS = 10
+    },
 
-	VEHICLES = {
-		-- distance for the "enter vehicle" command
-		MIN_DISTANCE_VEHICLE_ENTER = 10.0,
-		-- once a jet is that low above a vehicle or person he aborts
-		ABORT_ATTACK_HEIGHT_JET = 50,
-		-- once a jet is that far away from a vehicle or person he aborts
-		ABORT_ATTACK_DISTANCE_JET = 120,
-		-- once a jet is that far away from a jet or chopper he aborts
-		ABORT_ATTACK_AIR_DISTANCE_JET = 50,
-		-- once a chopper is that low above a vehicle or person he aborts
-		ABORT_ATTACK_HEIGHT_CHOPPER = 20,
-		-- in this time a jet will not attack
-		JET_TAKEOFF_TIME = 20,
-		-- time a jet waits after an attack
-		JET_ABORT_ATTACK_TIME = 5,
-		-- percentage of vehicle health to leave vehicle with (currently no passive events for bot-only vehicles)
-		VEHILCE_EXIT_HEALTH = 12,
-		-- propability to exit on low health
-		VEHICLE_PROPABILITY_EXIT_LOW_HEALTH = 60,
-		-- health-check cycle-time
-		VEHICLE_HEALTH_CYLCE_TIME = 0.5,
-		-- seat-check cycle-time
-		VEHICLE_SEAT_CHECK_CYCLE_TIME = 4.0,
-	},
+    VEHICLES = {
+        -- distance for the "enter vehicle" command
+        MIN_DISTANCE_VEHICLE_ENTER = 10.0,
+        -- once a jet is that low above a vehicle or person, he aborts
+        ABORT_ATTACK_HEIGHT_JET = 50,
+        -- once a jet is that far away from a vehicle or person, he aborts
+        ABORT_ATTACK_DISTANCE_JET = 120,
+        -- once a jet is that far away from a jet or chopper, he aborts
+        ABORT_ATTACK_AIR_DISTANCE_JET = 50,
+        -- once a chopper is that low above a vehicle or person, he aborts
+        ABORT_ATTACK_HEIGHT_CHOPPER = 20,
+        -- in this time a jet will not attack
+        JET_TAKEOFF_TIME = 20,
+        -- time a jet waits after an attack
+        JET_ABORT_ATTACK_TIME = 5,
+        -- percentage of vehicle health to leave vehicle with (currently no passive events for bot-only vehicles)
+        VEHILCE_EXIT_HEALTH = 12,
+        -- propability to exit on low health
+        VEHICLE_PROPABILITY_EXIT_LOW_HEALTH = 60,
+        -- health-check cycle-time
+        VEHICLE_HEALTH_CYLCE_TIME = 0.5,
+        -- seat-check cycle-time
+        VEHICLE_SEAT_CHECK_CYCLE_TIME = 4.0
+    },
 
-	-- Bot related
-	BOT = {
-		-- Update cycle fast
-		BOT_FAST_UPDATE_CYCLE = 0.03, -- equals 30 fps
-		-- Update cycle
-		BOT_UPDATE_CYCLE = 0.1,
-		-- - distance the bots have to reach in height to continue with next Waypoint
-		TARGET_HEIGHT_DISTANCE_WAYPOINT = 1.5,
-		-- Chance that the bot will teleport when they are stuck.
-		PROBABILITY_TELEPORT_IF_STUCK = 80,
-		-- Chance that the bot will teleport when they are stuck in a vehicle.
-		PROBABILITY_TELEPORT_IF_STUCK_IN_VEHICLE = 20,
-		-- At the end of an attack cycle, chance of throwing a grenade.
-		PROBABILITY_THROW_GRENADE = 80,
-		-- the probabilty to use the rocket instead of the a primary
-		PROBABILITY_SHOOT_ROCKET = 33,
-		-- the probabilty to use the rifle to attack a chopper
-		PROBABILITY_ATTACK_CHOPPER_WITH_RIFLE = 25,
-		-- If the gamemode is Rush or Conquest, change direction if the bot is stuck on non-connecting paths.
-		PROBABILITY_CHANGE_DIRECTION_IF_STUCK = 50,
-		-- Trace delta a bot uses when they are off a trace path to find his way back to the best path
-		TRACE_DELTA_SHOOTING = 0.4,
-		-- The max time a bot tries to move to the repair-vehicle
-		MAX_TIME_TRY_REPAIR = 10,
-		-- Advanced aiming makes a difference on huge distances, but costs more performance
-		USE_ADVANCED_AIMING = false,
-	},
+    -- Bot related
+    BOT = {
+        -- Update cycle fast
+        BOT_FAST_UPDATE_CYCLE = 0.03, -- equals 30 fps
+        -- Update cycle
+        BOT_UPDATE_CYCLE = 0.1,
+        -- - distance the bots have to reach in height to continue with next Waypoint
+        TARGET_HEIGHT_DISTANCE_WAYPOINT = 1.5,
+        -- Chance that the bot will teleport when they are stuck.
+        PROBABILITY_TELEPORT_IF_STUCK = 80,
+        -- Chance that the bot will teleport when they are stuck in a vehicle.
+        PROBABILITY_TELEPORT_IF_STUCK_IN_VEHICLE = 20,
+        -- At the end of an attack cycle, chance of throwing a grenade.
+        PROBABILITY_THROW_GRENADE = 80,
+        -- the probability to use the rocket instead of the a primary
+        PROBABILITY_SHOOT_ROCKET = 33,
+        -- the probability to use the rifle to attack a chopper
+        PROBABILITY_ATTACK_CHOPPER_WITH_RIFLE = 25,
+        -- If the gamemode is Rush or Conquest, change direction if the bot is stuck on non-connecting paths.
+        PROBABILITY_CHANGE_DIRECTION_IF_STUCK = 50,
+        -- Trace delta a bot uses when they are off a trace path to find his way back to the best path
+        TRACE_DELTA_SHOOTING = 0.4,
+        -- The max time a bot tries to move to the repair-vehicle
+        MAX_TIME_TRY_REPAIR = 10,
+        -- Advanced aiming makes a difference on huge distances, but costs more performance
+        USE_ADVANCED_AIMING = false
+    },
 
-	-- Bot team balancing (only in keep_playercount - spawn-mode)
-	BOT_TEAM_BALANCING = {
-		-- Minimum amount of players required before balancing bots across teams
-		-- Note: Only for mode keep_playercount
-		THRESHOLD = 6, -- only for mode
-		-- Maximum bot count difference between both teams (even count: 1, uneven: 2)
-		-- Note: Only for mode keep_playercount
-		ALLOWED_DIFFERENCE = 1,
-	},
+    -- Bot team balancing (only in keep_playercount - spawn-mode)
+    BOT_TEAM_BALANCING = {
+        -- Minimum amount of players required before balancing bots across teams
+        -- Note: Only for mode keep_playercount
+        THRESHOLD = 6, -- only for mode
+        -- Maximum bot count difference between both teams (even count: 1, uneven: 2)
+        -- Note: Only for mode keep_playercount
+        ALLOWED_DIFFERENCE = 1
+    },
 
-	-- Bot spawning
-	BOT_SPAWN = {
-		-- Time between a level loading and the first bot spawning
-		-- Note: Must be big enough to register inputActiveEvents (> 1.0)
-		FIRST_SPAWN_DELAY = 5.0,
-		-- Probability of a bot spawning on a member of the same squad.
-		PROBABILITY_SQUADMATE_SPAWN = 40,
-		-- Probability of a bot spawning in the vehicle of a bot of the same squad.
-		PROBABILITY_SQUADMATE_VEHICLE_SPAWN = 60,
-		-- Probability of a bot spawning in the vehicle of a player of the same squad.
-		PROBABILITY_SQUADMATE_PLAYER_VEHICLE_SPAWN = 80,
-		-- Probability of a bot spawning on the closest spawn point
-		PROBABILITY_CLOSEST_SPAWN = 80,
-		-- Probability of a bot spawning on an attacked spawn point
-		PROBABILITY_ATTACKED_SPAWN = 80,
-		-- Probability of a bot spawning on their deployment base.
-		PROBABILITY_BASE_SPAWN = 15,
-	}
+    -- Bot spawning
+    BOT_SPAWN = {
+        -- Time between a level loading and the first bot spawning
+        -- Note: Must be big enough to register inputActiveEvents (> 1.0)
+        FIRST_SPAWN_DELAY = 5.0,
+        -- Probability of a bot spawning on a member of the same squad.
+        PROBABILITY_SQUADMATE_SPAWN = 40,
+        -- Probability of a bot spawning in the vehicle of a bot of the same squad.
+        PROBABILITY_SQUADMATE_VEHICLE_SPAWN = 60,
+        -- Probability of a bot spawning in the vehicle of a player of the same squad.
+        PROBABILITY_SQUADMATE_PLAYER_VEHICLE_SPAWN = 80,
+        -- Probability of a bot spawning on the closest spawn point
+        PROBABILITY_CLOSEST_SPAWN = 80,
+        -- Probability of a bot spawning on an attacked spawn point
+        PROBABILITY_ATTACKED_SPAWN = 80,
+        -- Probability of a bot spawning on their deployment base.
+        PROBABILITY_BASE_SPAWN = 15
+    }
 }

--- a/ext/Shared/Registry/RegistryManager.lua
+++ b/ext/Shared/Registry/RegistryManager.lua
@@ -1,6 +1,6 @@
 ---@class RegistryManager
 ---@overload fun():RegistryManager
-RegistryManager = class 'RegistryManager'
+RegistryManager = class('RegistryManager')
 
 require('__shared/Registry/Registry')
 
@@ -10,22 +10,18 @@ require('__shared/Registry/Registry')
 -- @release V2.2.0 - 22/08/21
 local MODULE_NAME = "Registry Manager"
 
-
-local m_registryUtil = nil
-
 function RegistryManager:__init()
-	local s_start = SharedUtils:GetTimeMS()
-
-	m_registryUtil = require('__shared/Registry/RegistryUtil')
-
-	print("Enabled \"" .. MODULE_NAME .. "\" in " .. ReadableTimetamp(SharedUtils:GetTimeMS() - s_start, TimeUnits.FIT, 1))
+    self._StartTime = SharedUtils:GetTimeMS()
+    self._RegistryUtil = require('__shared/Registry/RegistryUtil')
+    print("Enabled \"" .. MODULE_NAME .. "\" in " ..
+              ReadableTimetamp(SharedUtils:GetTimeMS() - self._StartTime, TimeUnits.FIT, 1))
 end
 
 -- Get the Registry Util containing non-essential and non-core functions.
 -- @return String - semantic version
 -- @author Firjen <https://github.com/Firjens>
 function RegistryManager:GetUtil()
-	return m_registryUtil
+    return self._RegistryUtil
 end
 
 -- Check if a variable is currently in the registry, if not return the default value.
@@ -36,15 +32,15 @@ end
 -- @author Firjen <https://github.com/Firjens>
 -- @todo Add indispensable
 function RegistryManager:Get(variable, default, indispensable)
-	if variable == nil then
-		return default
-	end
-
-	return default
+    if variable == nil then
+        return default
+    else
+        return variable
+    end
 end
 
 if g_RegistryManager == nil then
-	g_RegistryManager = RegistryManager()
+    g_RegistryManager = RegistryManager()
 end
 
 return g_RegistryManager

--- a/ext/Shared/Registry/RegistryUtil.lua
+++ b/ext/Shared/Registry/RegistryUtil.lua
@@ -1,6 +1,6 @@
 ---@class RegistryUtil
 ---@overload fun():RegistryUtil
-RegistryUtil = class 'RegistryUtil'
+RegistryUtil = class('RegistryUtil')
 
 require('__shared/Registry/Registry')
 
@@ -10,36 +10,34 @@ require('__shared/Registry/Registry')
 local MODULE_NAME = "Registry Manager: Util"
 
 function RegistryUtil:__init()
-	local s_start = SharedUtils:GetTimeMS()
-
-	print("Enabled \"" .. MODULE_NAME .. "\" in " .. ReadableTimetamp(SharedUtils:GetTimeMS() - s_start, TimeUnits.FIT, 1))
+    self._StartTime = SharedUtils:GetTimeMS()
+    print("Enabled \"" .. MODULE_NAME .. "\" in " ..
+              ReadableTimetamp(SharedUtils:GetTimeMS() - self._StartTime, TimeUnits.FIT, 1))
 end
 
 -- Get the version of the current build as in a semantic format.
 -- @return String - semantic version
 -- @author Firjen <https://github.com/Firjens>
 function RegistryUtil:GetVersion()
-	-- If there is no label, we return the MAJ.MIN.PATCH, otherwise we need
-	-- to return the MAJ.MIN.PATCH-LABEL.
-	if Registry.VERSION.VERSION_LABEL == nil or Registry.VERSION.VERSION_LABEL == "" or
-		Registry.VERSION.VERSION_TYPE == VersionType.Release then
-		return "V" ..
-			Registry.VERSION.VERSION_MAJ .. "." .. Registry.VERSION.VERSION_MIN .. "." .. Registry.VERSION.VERSION_PATCH;
-	else
-		if Registry.VERSION.VERSION_TYPE == VersionType.DevBuild then
-			return "v" ..
-				Registry.VERSION.VERSION_MAJ ..
-				"." .. Registry.VERSION.VERSION_MIN .. "." .. Registry.VERSION.VERSION_PATCH .. "-" .. Registry.VERSION.VERSION_LABEL;
-		elseif Registry.VERSION.VERSION_TYPE == VersionType.Stable then
-			return "V" ..
-				Registry.VERSION.VERSION_MAJ ..
-				"." .. Registry.VERSION.VERSION_MIN .. "." .. Registry.VERSION.VERSION_PATCH .. "-" .. Registry.VERSION.VERSION_LABEL;
-		end
-	end
+    -- If there is no label, we return the MAJ.MIN.PATCH, otherwise we need
+    -- to return the MAJ.MIN.PATCH-LABEL.
+    if Registry.VERSION.VERSION_LABEL == nil or Registry.VERSION.VERSION_LABEL == "" or Registry.VERSION.VERSION_TYPE ==
+        VersionType.Release then
+        return "V" .. Registry.VERSION.VERSION_MAJ .. "." .. Registry.VERSION.VERSION_MIN .. "." ..
+                   Registry.VERSION.VERSION_PATCH;
+    else
+        MAJ_MIN_PATCH_LABEL = Registry.VERSION.VERSION_MAJ .. "." .. Registry.VERSION.VERSION_MIN .. "." ..
+                                  Registry.VERSION.VERSION_PATCH .. "-" .. Registry.VERSION.VERSION_LABEL
+        if Registry.VERSION.VERSION_TYPE == VersionType.DevBuild then
+            return "v" .. MAJ_MIN_PATCH_LABEL
+        elseif Registry.VERSION.VERSION_TYPE == VersionType.Stable then
+            return "V" .. MAJ_MIN_PATCH_LABEL
+        end
+    end
 end
 
 if g_RegistryUtil == nil then
-	---@type RegistryUtil
+    ---@type RegistryUtil
 	g_RegistryUtil = RegistryUtil()
 end
 


### PR DESCRIPTION
I used the configs in `.editorconfig` on my Lua extension in VSCode and formatted these files, didn't change anything in the code (only style), except that:

In `Registry.lua` and `ClientBotManager.lua` I fixed the grammar of this variable: `USE_COLLITION_RAYCASTS` -> `USE_COLLISION_RAYCASTS`, and some other grammar stuff on comments;

In both `RegistryManager.lua` and `RegistryUtil.lua` I standardized the notation of these files with the other ones, like `self._VariableName`;

In `ArrayMap.lua` I simplified the for loops comparing the data of `self._Entries` with the passed argument directly;

Last, I fixed the `RegistryManager:Get` method, it was never returning the `variable` value, even when `value ~= nil`, it returned `default`. This method is used no where, but now it'll work properly if it's needed.


