### PR TITLE
remove: unused local variables; fix: float compare error 

### DIFF
--- a/ext/Client/ClientNodeEditor.lua
+++ b/ext/Client/ClientNodeEditor.lua
@@ -1,11 +1,11 @@
 ---@class ClientNodeEditor
 ---@overload fun():ClientNodeEditor
-ClientNodeEditor = class "ClientNodeEditor"
+ClientNodeEditor = class('ClientNodeEditor')
 
 require('__shared/Config')
 
 ---@type Logger
-local m_Logger = Logger("ClientNodeEditor", Debug.Client.NODEEDITOR)
+local m_Logger = Logger('ClientNodeEditor', Debug.Client.NODEEDITOR)
 
 function ClientNodeEditor:__init()
 	-- Data Points. 
@@ -46,14 +46,14 @@ function ClientNodeEditor:__init()
 	self.m_ObbToDraw_temp = {}
 
 	self.m_Colors = {
-		["Text"] = Vec4(1, 1, 1, 1),
-		["White"] = Vec4(1, 1, 1, 1),
-		["Red"] = Vec4(1, 0, 0, 1),
-		["Green"] = Vec4(0, 1, 0, 1),
-		["Blue"] = Vec4(0, 0, 1, 1),
-		["Purple"] = Vec4(0.5, 0, 1, 1),
-		["Ray"] = { Node = Vec4(1, 1, 1, 0.2), Line = { Vec4(1, 1, 1, 1), Vec4(0, 0, 0, 1) } },
-		["Orphan"] = { Node = Vec4(0, 0, 0, 0.5), Line = Vec4(0, 0, 0, 1) },
+		['Text'] = Vec4(1, 1, 1, 1),
+		['White'] = Vec4(1, 1, 1, 1),
+		['Red'] = Vec4(1, 0, 0, 1),
+		['Green'] = Vec4(0, 1, 0, 1),
+		['Blue'] = Vec4(0, 0, 1, 1),
+		['Purple'] = Vec4(0.5, 0, 1, 1),
+		['Ray'] = { Node = Vec4(1, 1, 1, 0.2), Line = { Vec4(1, 1, 1, 1), Vec4(0, 0, 0, 1) } },
+		['Orphan'] = { Node = Vec4(0, 0, 0, 0.5), Line = Vec4(0, 0, 0, 1) },
 		{ Node = Vec4(1, 0, 0, 0.25), Line = Vec4(1, 0, 0, 1) },
 		{ Node = Vec4(1, 0.55, 0, 0.25), Line = Vec4(1, 0.55, 0, 1) },
 		{ Node = Vec4(1, 1, 0, 0.25), Line = Vec4(1, 1, 0, 1) },
@@ -101,7 +101,6 @@ function ClientNodeEditor:OnRegisterEvents()
 	NetEvents:Subscribe('UI_CommoRose_Action_SelectBetween', self, self._onSelectBetween)
 	NetEvents:Subscribe('UI_CommoRose_Action_SetInput', self, self._onSetInputNode)
 	NetEvents:Subscribe('ClientNodeEditor:SelectNewNode', self, self._onSelectNewNode)
-
 
 	-- Add these Events to NodeEditor. 
 	Console:Register('Select', 'Select or Deselect the waypoint you are looking at', self, self._onSelectNode) -- Done 
@@ -232,12 +231,12 @@ function ClientNodeEditor:_DrawData(p_DataPoint)
 		NextPos = nil,
 		IsTrace = false,
 		IsOthersTrace = false
-	}--]] 
+	}
+	--]] 
 
 	local s_IsSelected = p_DataPoint.IsSelected
 	local s_QualityAtRange = p_DataPoint.DrawLine
 	local s_IsTracePath = p_DataPoint.IsTrace
-	local s_IsOtherTracePath = false
 	local s_Waypoint = p_DataPoint.Node
 
 	-- Setup node colour information. 
@@ -253,7 +252,6 @@ function ClientNodeEditor:_DrawData(p_DataPoint)
 	end
 
 	s_Color = self.m_Colors[s_Waypoint.PathIndex]
-
 
 	if s_IsTracePath then
 		s_Color = {
@@ -349,14 +347,14 @@ function ClientNodeEditor:_DrawData(p_DataPoint)
 
 			local s_Text = ''
 			-- s_Text = s_Text .. string.format("(%s)Pevious [ %s ] Next(%s)\n", s_PreviousNode, p_Waypoint.ID, s_NextNode) 
-			s_Text = s_Text .. string.format("Index[%d]\n", s_Waypoint.Index)
-			s_Text = s_Text .. string.format("Path[%d][%d] (%s)\n", s_Waypoint.PathIndex, s_Waypoint.PointIndex, s_PathMode)
-			s_Text = s_Text .. string.format("Path Objectives: %s\n", g_Utilities:dump(p_DataPoint.Objectives, false))
-			s_Text = s_Text .. string.format("Vehicles: %s\n", g_Utilities:dump(p_DataPoint.Vehicles, false))
-			s_Text = s_Text .. string.format("InputVar: %d\n", s_Waypoint.InputVar)
-			s_Text = s_Text .. string.format("SpeedMode: %s (%d)\n", s_SpeedMode, s_Waypoint.SpeedMode)
-			s_Text = s_Text .. string.format("ExtraMode: %s (%d)\n", s_ExtraMode, s_Waypoint.ExtraMode)
-			s_Text = s_Text .. string.format("OptValue: %s (%d)\n", s_OptionValue, s_Waypoint.OptValue)
+			s_Text = s_Text .. string.format('Index[%d]\n', s_Waypoint.Index)
+			s_Text = s_Text .. string.format('Path[%d][%d] (%s)\n', s_Waypoint.PathIndex, s_Waypoint.PointIndex, s_PathMode)
+			s_Text = s_Text .. string.format('Path Objectives: %s\n', g_Utilities:dump(p_DataPoint.Objectives, false))
+			s_Text = s_Text .. string.format('Vehicles: %s\n', g_Utilities:dump(p_DataPoint.Vehicles, false))
+			s_Text = s_Text .. string.format('InputVar: %d\n', s_Waypoint.InputVar)
+			s_Text = s_Text .. string.format('SpeedMode: %s (%d)\n', s_SpeedMode, s_Waypoint.SpeedMode)
+			s_Text = s_Text .. string.format('ExtraMode: %s (%d)\n', s_ExtraMode, s_Waypoint.ExtraMode)
+			s_Text = s_Text .. string.format('OptValue: %s (%d)\n', s_OptionValue, s_Waypoint.OptValue)
 			s_Text = s_Text .. 'Data: ' .. g_Utilities:dump(s_Waypoint.Data, true)
 
 			self:DrawPosText2D(s_Waypoint.Position + Vec3.up, s_Text, self.m_Colors.Text, 1.2)
@@ -469,7 +467,7 @@ function ClientNodeEditor:_onToggleMoveNode(p_Args)
 			self:Log('Move Cancelled')
 
 			local s_UpdateData = {}
-			local s_Selection  = self:GetSelectedNodes()
+			local s_Selection = self:GetSelectedNodes()
 
 			for i = 1, #s_Selection do
 				local s_UpdateNode = {
@@ -654,9 +652,11 @@ end
 ---@param p_ParentGraph DataContainer
 ---@param p_StateNodeGuid Guid|nil
 function ClientNodeEditor:OnUIPushScreen(p_HookCtx, p_Screen, p_Priority, p_ParentGraph, p_StateNodeGuid)
-	if self.m_Enabled and self.m_CommoRoseEnabled and p_Screen ~= nil and
-		UIScreenAsset(p_Screen).name == 'UI/Flow/Screen/CommRoseScreen' then
-		-- self:Log('Blocked vanilla Comm Rose') 
+	if self.m_Enabled and 
+	self.m_CommoRoseEnabled and 
+	p_Screen ~= nil and
+	UIScreenAsset(p_Screen).name == 'UI/Flow/Screen/CommRoseScreen' then
+		-- self:Log('Blocked vanilla Commo Rose') 
 		p_HookCtx:Return()
 		return
 	end
@@ -874,7 +874,6 @@ function ClientNodeEditor:OnUpdateManagerUpdate(p_DeltaTime, p_UpdatePass)
 							end
 						end
 
-
 						-- Loop selected nodes and update positions. 
 						local s_UpdateData = {}
 
@@ -947,7 +946,7 @@ function ClientNodeEditor:DrawSphere(p_Position, p_Size, p_Color, p_RenderLines,
 		radius = p_Size,
 		color = p_Color,
 		renderLines = p_RenderLines,
-		smallSizeSegmentDecrease = p_SmallSizeSegmentDecrease
+		smallSizeSegmentDecrease = p_SmallSizeSegmentDecrease,
 	})
 end
 
@@ -956,7 +955,7 @@ function ClientNodeEditor:DrawLine(p_From, p_To, p_ColorFrom, p_ColorTo)
 		from = p_From,
 		to = p_To,
 		colorFrom = p_ColorFrom,
-		colorTo = p_ColorTo
+		colorTo = p_ColorTo,
 	})
 end
 
@@ -966,7 +965,7 @@ function ClientNodeEditor:DrawText2D(p_X, p_Y, p_Text, p_Color, p_Scale)
 		y = p_Y,
 		text = p_Text,
 		color = p_Color,
-		scale = p_Scale
+		scale = p_Scale,
 	})
 end
 
@@ -975,7 +974,7 @@ function ClientNodeEditor:DrawPosText2D(p_Pos, p_Text, p_Color, p_Scale)
 		pos = p_Pos,
 		text = p_Text,
 		color = p_Color,
-		scale = p_Scale
+		scale = p_Scale,
 	})
 end
 
@@ -983,7 +982,7 @@ function ClientNodeEditor:DrawOBB(p_Aab, p_Transform, p_Color)
 	table.insert(self.m_ObbToDraw_temp, {
 		aab = p_Aab,
 		transform = p_Transform,
-		color = p_Color
+		color = p_Color,
 	})
 end
 

--- a/ext/Server/AirTargets.lua
+++ b/ext/Server/AirTargets.lua
@@ -5,10 +5,7 @@ AirTargets = class('AirTargets')
 ---@type Utilities
 local m_Utilities = require('__shared/Utilities')
 ---@type Vehicles
-local m_Vehicles = require("Vehicles")
----@type Logger
-local m_Logger = Logger("BotManager", Debug.Server.BOT)
-
+local m_Vehicles = require('Vehicles')
 
 function AirTargets:__init()
 	self._Targets = {}

--- a/ext/Server/Bot.lua
+++ b/ext/Server/Bot.lua
@@ -10,11 +10,11 @@ local m_NodeCollection = require('NodeCollection')
 ---@type PathSwitcher
 local m_PathSwitcher = require('PathSwitcher')
 ---@type Vehicles
-local m_Vehicles = require("Vehicles")
+local m_Vehicles = require('Vehicles')
 ---@type AirTargets
-local m_AirTargets = require("AirTargets")
+local m_AirTargets = require('AirTargets')
 ---@type Logger
-local m_Logger = Logger("Bot", Debug.Server.BOT)
+local m_Logger = Logger('Bot', Debug.Server.BOT)
 
 local m_BotAiming = require('Bot/BotAiming')
 local m_BotAttacking = require('Bot/BotAttacking')
@@ -24,8 +24,6 @@ local m_VehicleAiming = require('Bot/VehicleAiming')
 local m_VehicleAttacking = require('Bot/VehicleAttacking')
 local m_VehicleMovement = require('Bot/VehicleMovement')
 local m_VehicleWeaponHandling = require('Bot/VehicleWeaponHandling')
-
-
 
 ---@param p_Player Player
 function Bot:__init(p_Player)
@@ -169,7 +167,7 @@ function Bot:__init(p_Player)
 	self._ShootPlayer = nil
 	---@type VehicleTypes
 	self._ShootPlayerVehicleType = VehicleTypes.NoVehicle
-	self._ShootPlayerName = ""
+	self._ShootPlayerName = ''
 	self._DistanceToPlayer = 0.0
 	---@type BotWeapons
 	self._WeaponToUse = BotWeapons.Primary
@@ -410,9 +408,11 @@ end
 
 ---@param p_Player Player
 function Bot:Revive(p_Player)
-	if self.m_Kit == BotKits.Assault and p_Player.corpse and not p_Player.corpse.isDead
-		and not Globals.IsGm and
-		not Globals.IsScavenger then
+	if self.m_Kit == BotKits.Assault and 
+	p_Player.corpse and 
+	not p_Player.corpse.isDead and
+	not Globals.IsGm and
+	not Globals.IsScavenger then
 		if Config.BotsRevive then
 			self._ActiveAction = BotActionFlags.ReviveActive
 			self._ShootPlayer = nil
@@ -653,8 +653,6 @@ function Bot:ShootAt(p_Player, p_IgnoreYaw)
 		return false
 	end
 
-
-
 	self._ShootPlayerVehicleType = s_Type
 
 	local s_DifferenceYaw = 0
@@ -739,7 +737,7 @@ function Bot:ShootAt(p_Player, p_IgnoreYaw)
 
 			return true
 		else
-			self._ShootPlayerName = ""
+			self._ShootPlayerName = ''
 			self._ShootPlayer = nil
 			if self.m_InVehicle then
 				self._ShootModeTimer = Config.BotVehicleFireModeDuration
@@ -811,7 +809,7 @@ function Bot:_CheckForVehicleActions(p_DeltaTime, p_AttackActive)
 				for l_SeatIndex = 0, self.m_Player.controlledEntryId do
 					if s_VehicleEntity:GetPlayerInEntry(l_SeatIndex) == nil then
 						-- Better seat available → switch seats. 
-						m_Logger:Write("switch to better seat")
+						m_Logger:Write('switch to better seat')
 						self:AbortAttack()
 						self.m_Player:EnterVehicle(s_VehicleEntity, l_SeatIndex)
 						self:UpdateVehicleMovableId()
@@ -832,7 +830,7 @@ function Bot:_CheckForVehicleActions(p_DeltaTime, p_AttackActive)
 						s_LowestSeatIndex = l_SeatIndex
 					else -- Check if there is a gap. 
 						if s_LowestSeatIndex >= 0 then -- There is a better place. 
-							m_Logger:Write("switch to better seat")
+							m_Logger:Write('switch to better seat')
 							self:AbortAttack()
 							self.m_Player:EnterVehicle(s_VehicleEntity, s_LowestSeatIndex)
 							self:UpdateVehicleMovableId()
@@ -854,7 +852,7 @@ function Bot:ResetVars()
 	self._Shoot = false
 	self._TargetPlayer = nil
 	self._ShootPlayer = nil
-	self._ShootPlayerName = ""
+	self._ShootPlayerName = ''
 	self._InvertPathDirection = false
 	self._ExitVehicleActive = false
 	self._ShotTimer = 0.0
@@ -922,8 +920,9 @@ end
 
 ---@return boolean
 function Bot:IsStaticMovement()
-	if self._MoveMode == BotMoveModes.Standstill or self._MoveMode == BotMoveModes.Mirror or
-		self._MoveMode == BotMoveModes.Mimic then
+	if self._MoveMode == BotMoveModes.Standstill or 
+	self._MoveMode == BotMoveModes.Mirror or
+	self._MoveMode == BotMoveModes.Mimic then
 		return true
 	else
 		return false
@@ -1002,7 +1001,7 @@ end
 
 ---@return boolean
 function Bot:IsStuck()
-	if self._ObstaceSequenceTimer ~= 0.0 then
+	if self._ObstaceSequenceTimer ~= 0 then
 		return true
 	else
 		return false
@@ -1015,7 +1014,7 @@ function Bot:ResetSpawnVars()
 	self._ObstacleRetryCounter = 0
 	self._LastWayDistance = 1000.0
 	self._ShootPlayer = nil
-	self._ShootPlayerName = ""
+	self._ShootPlayerName = ''
 	self._ShootModeTimer = 0.0
 	self._MeleeCooldownTimer = 0.0
 	self._ShootTraceTimer = 0.0
@@ -1053,7 +1052,7 @@ function Bot:ResetSpawnVars()
 	for l_EIA = 0, 36 do
 		self.m_ActiveInputs[l_EIA] = {
 			value = 0,
-			reset = false
+			reset = false,
 		}
 		self.m_Player.input:SetLevel(l_EIA, 0.0)
 	end
@@ -1072,7 +1071,7 @@ function Bot:ClearPlayer(p_Player)
 	local s_CurrentShootPlayer = PlayerManager:GetPlayerByName(self._ShootPlayerName)
 
 	if s_CurrentShootPlayer == p_Player then
-		self._ShootPlayerName = ""
+		self._ShootPlayerName = ''
 	end
 end
 
@@ -1139,7 +1138,7 @@ end
 function Bot:_SetInput(p_Input, p_Value)
 	self.m_ActiveInputs[p_Input] = {
 		value = p_Value,
-		reset = p_Value == 0.0
+		reset = p_Value == 0,
 	}
 end
 
@@ -1326,7 +1325,7 @@ end
 ---@return integer
 ---@return Vec3|nil
 function Bot:_EnterVehicle(p_PlayerIsDriver)
-	local s_Iterator = EntityManager:GetIterator("ServerVehicleEntity")
+	local s_Iterator = EntityManager:GetIterator('ServerVehicleEntity')
 	local s_Entity = s_Iterator:Next()
 
 	local s_ClosestEntity = nil
@@ -1387,7 +1386,7 @@ function Bot:_GetWayIndex(p_CurrentWayPoint)
 end
 
 function Bot:AbortAttack()
-	if m_Vehicles:IsVehicleType(self.m_ActiveVehicle, VehicleTypes.Plane) and self._ShootPlayerName ~= "" then
+	if m_Vehicles:IsVehicleType(self.m_ActiveVehicle, VehicleTypes.Plane) and self._ShootPlayerName ~= '' then
 		self._VehicleTakeoffTimer = Registry.VEHICLES.JET_ABORT_ATTACK_TIME
 		self._JetAbortAttackActive = true
 		self._Pid_Drv_Yaw:Reset()
@@ -1396,7 +1395,7 @@ function Bot:AbortAttack()
 	end
 
 	self.m_Player.input.zoomLevel = 0
-	self._ShootPlayerName = ""
+	self._ShootPlayerName = ''
 	self._ShootPlayer = nil
 	self._ShootModeTimer = 0.0
 	self._AttackMode = BotAttackModes.RandomNotSet
@@ -1414,7 +1413,7 @@ function Bot:_ResetActionFlag(p_FlagValue)
 end
 
 function Bot:_SetActiveVars()
-	if self._ShootPlayerName ~= "" then
+	if self._ShootPlayerName ~= '' then
 		self._ShootPlayer = PlayerManager:GetPlayerByName(self._ShootPlayerName)
 	else
 		self._ShootPlayer = nil
@@ -1423,7 +1422,7 @@ function Bot:_SetActiveVars()
 	self.m_ActiveMoveMode = self._MoveMode
 	self.m_ActiveSpeedValue = self._BotSpeed
 
-	if self.m_Player.controlledControllable ~= nil and not self.m_Player.controlledControllable:Is("ServerSoldierEntity") then
+	if self.m_Player.controlledControllable ~= nil and not self.m_Player.controlledControllable:Is('ServerSoldierEntity') then
 		self.m_InVehicle = true
 		self.m_OnVehicle = false
 	elseif self.m_Player.attachedControllable ~= nil then

--- a/ext/Server/Bot/BotMovement.lua
+++ b/ext/Server/Bot/BotMovement.lua
@@ -3,7 +3,7 @@
 BotMovement = class('BotMovement')
 
 ---@type Logger
-local m_Logger = Logger("Bot", Debug.Server.BOT)
+local m_Logger = Logger('Bot', Debug.Server.BOT)
 ---@type Utilities
 local m_Utilities = require('__shared/Utilities')
 ---@type PathSwitcher
@@ -48,7 +48,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 			if not p_Bot._InvertPathDirection then
 				s_NextPoint = m_NodeCollection:Get(p_Bot:_GetWayIndex(p_Bot._CurrentWayPoint + 1), p_Bot._PathIndex)
 
-			--[[if Config.DebugTracePaths then 
+				--[[if Config.DebugTracePaths then 
 					NetEvents:BroadcastLocal('ClientNodeEditor:BotSelect', p_Bot._PathIndex, p_Bot:_GetWayIndex(p_Bot._CurrentWayPoint + 1), p_Bot.m_Player.soldier.worldTransform.trans, (p_Bot._ObstaceSequenceTimer > 0.0), "Green")
 				end--]] 
 			else
@@ -63,7 +63,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 		-- Execute Action if needed. 
 		if p_Bot._ActiveAction == BotActionFlags.OtherActionActive then
 			if s_Point.Data ~= nil and s_Point.Data.Action ~= nil then
-				if s_Point.Data.Action.type == "vehicle" then
+				if s_Point.Data.Action.type == 'vehicle' then
 					if Config.UseVehicles then
 						local s_RetCode, s_Position = p_Bot:_EnterVehicle(false)
 						if s_RetCode == 0 then
@@ -128,7 +128,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 			-- Sidewards movement. 
 			if Config.MoveSidewards then
 				if p_Bot._SidewardsTimer <= 0.0 then
-					if p_Bot.m_StrafeValue ~= 0.0 then
+					if p_Bot.m_StrafeValue ~= 0 then
 						p_Bot._SidewardsTimer = MathUtils:GetRandom(Config.MinMoveCycle, Config.MaxStraigtCycle)
 						p_Bot.m_StrafeValue = 0.0
 						p_Bot.m_YawOffset = 0.0
@@ -164,7 +164,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 			-- Detect obstacle and move over or around. To-do: Move before normal jump. 
 			local s_CurrentWayPointDistance = p_Bot.m_Player.soldier.worldTransform.trans:Distance(s_Point.Position)
 
-			if s_CurrentWayPointDistance > p_Bot._LastWayDistance + 0.02 and p_Bot._ObstaceSequenceTimer == 0.0 then
+			if s_CurrentWayPointDistance > p_Bot._LastWayDistance + 0.02 and p_Bot._ObstaceSequenceTimer == 0 then
 				-- Skip one point. 
 				s_DistanceFromTarget = 0
 				s_HeightDistance = 0
@@ -173,11 +173,11 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 			p_Bot._TargetPoint = s_Point
 			p_Bot._NextTargetPoint = s_NextPoint
 
-			if math.abs(s_CurrentWayPointDistance - p_Bot._LastWayDistance) < 0.02 or p_Bot._ObstaceSequenceTimer ~= 0.0 then
+			if math.abs(s_CurrentWayPointDistance - p_Bot._LastWayDistance) < 0.02 or p_Bot._ObstaceSequenceTimer ~= 0 then
 				-- Try to get around obstacle. 
 				p_Bot.m_ActiveSpeedValue = BotMoveSpeeds.Sprint -- Always try to stand. 
 
-				if p_Bot._ObstaceSequenceTimer == 0.0 then -- Step 0 
+				if p_Bot._ObstaceSequenceTimer == 0 then -- Step 0 
 				elseif p_Bot._ObstaceSequenceTimer > 2.4 then -- Step 4 - repeat afterwards. 
 					p_Bot._ObstaceSequenceTimer = 0.0
 					p_Bot:_ResetActionFlag(BotActionFlags.MeleeActive)
@@ -228,7 +228,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 						s_Transform.trans = p_Bot._TargetPoint.Position
 						s_Transform:LookAtTransform(p_Bot._TargetPoint.Position, p_Bot._NextTargetPoint.Position)
 						p_Bot.m_Player.soldier:SetTransform(s_Transform)
-						m_Logger:Write("tepeported " .. p_Bot.m_Player.name)
+						m_Logger:Write('teleported ' .. p_Bot.m_Player.name)
 					else
 						if not p_Bot.m_InVehicle then
 							s_PointIncrement = MathUtils:GetRandomInt(-5, 5) -- Go 5 points further. 
@@ -250,7 +250,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 				if p_Bot._StuckTimer > 15.0 then
 					p_Bot.m_Player.soldier:Kill()
 
-					m_Logger:Write(p_Bot.m_Player.name .. " got stuck. Kill")
+					m_Logger:Write(p_Bot.m_Player.name .. ' got stuck. Kill')
 
 					return
 				end
@@ -261,7 +261,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 			p_Bot._LastWayDistance = s_CurrentWayPointDistance
 
 			-- Jump detection. Much more simple now, but works fine -) 
-			if p_Bot._ObstaceSequenceTimer == 0.0 then
+			if p_Bot._ObstaceSequenceTimer == 0 then
 				if (s_Point.Position.y - p_Bot.m_Player.soldier.worldTransform.trans.y) > 0.3 and Config.JumpWhileMoving then
 					-- Detect, if a jump was recorded or not. 
 					local s_TimeForwardBackwardJumpDetection = 1.1 -- 1.5 s ahead and back. 
@@ -272,8 +272,7 @@ function BotMovement:UpdateNormalMovement(p_Bot)
 						local s_PointAfter = m_NodeCollection:Get(s_ActivePointIndex + i, p_Bot._PathIndex)
 
 						if (s_PointBefore ~= nil and s_PointBefore.ExtraMode == 1) or
-							(s_PointAfter ~= nil and s_PointAfter.ExtraMode == 1
-							) then
+							(s_PointAfter ~= nil and s_PointAfter.ExtraMode == 1) then
 							s_JumpValid = true
 							break
 						end
@@ -434,11 +433,11 @@ function BotMovement:UpdateShootMovement(p_Bot)
 
 	-- Crouch moving (only mode with modified gun). 
 	local s_ActiveWeaponType = p_Bot.m_ActiveWeapon.type
-	if (
-		(
-			s_ActiveWeaponType == WeaponTypes.Sniper or s_ActiveWeaponType == WeaponTypes.Rocket or
-				s_ActiveWeaponType == WeaponTypes.MissileAir or s_ActiveWeaponType == WeaponTypes.MissileLand) and
-			not p_Bot.m_KnifeMode) then -- Don't move while shooting some weapons. 
+	if ((s_ActiveWeaponType == WeaponTypes.Sniper or 
+	s_ActiveWeaponType == WeaponTypes.Rocket or
+	s_ActiveWeaponType == WeaponTypes.MissileAir or 
+	s_ActiveWeaponType == WeaponTypes.MissileLand) and
+	not p_Bot.m_KnifeMode) then -- Don't move while shooting some weapons. 
 		if p_Bot._AttackMode == BotAttackModes.Crouch then
 			if p_Bot.m_Player.soldier.pose ~= CharacterPoseType.CharacterPoseType_Crouch then
 				p_Bot.m_Player.soldier:SetPose(CharacterPoseType.CharacterPoseType_Crouch, true, true)
@@ -583,13 +582,13 @@ function BotMovement:LookAround(p_Bot, p_DeltaTime)
 			p_Bot._TargetYaw = p_Bot._TargetYaw + (2 * math.pi)
 		end
 	elseif p_Bot._WayWaitYawTimer >= 3.0 and s_LastYawTimer < 3.0 then
-		p_Bot._TargetYaw = p_Bot._TargetYaw - 1.0 -- 60° rotation left 
+		p_Bot._TargetYaw = p_Bot._TargetYaw - 1.0 -- 60° rotation left. 
 
 		if p_Bot._TargetYaw < 0.0 then
 			p_Bot._TargetYaw = p_Bot._TargetYaw + (2 * math.pi)
 		end
 	elseif p_Bot._WayWaitYawTimer >= 1.0 and s_LastYawTimer < 1.0 then
-		p_Bot._TargetYaw = p_Bot._TargetYaw + 1.0 -- 60° rotation right 
+		p_Bot._TargetYaw = p_Bot._TargetYaw + 1.0 -- 60° rotation right. 
 
 		if p_Bot._TargetYaw > (math.pi * 2) then
 			p_Bot._TargetYaw = p_Bot._TargetYaw - (2 * math.pi)
@@ -652,7 +651,11 @@ function BotMovement:UpdateStaticMovement(p_Bot)
 		end
 
 		p_Bot._TargetYaw = p_Bot._TargetPlayer.input.authoritativeAimingYaw +
-			((p_Bot._TargetPlayer.input.authoritativeAimingYaw > math.pi) and -math.pi or math.pi)
+			(
+				(p_Bot._TargetPlayer.input.authoritativeAimingYaw > math.pi) and
+				-math.pi or 
+				math.pi
+			)
 		p_Bot._TargetPitch = p_Bot._TargetPlayer.input.authoritativeAimingPitch
 	end
 end

--- a/ext/Server/Bot/VehicleMovement.lua
+++ b/ext/Server/Bot/VehicleMovement.lua
@@ -3,11 +3,11 @@
 VehicleMovement = class('VehicleMovement')
 
 ---@type Logger
-local m_Logger = Logger("Bot", Debug.Server.BOT)
+local m_Logger = Logger('Bot', Debug.Server.BOT)
 ---@type Utilities
 local m_Utilities = require('__shared/Utilities')
 ---@type Vehicles
-local m_Vehicles = require("Vehicles")
+local m_Vehicles = require('Vehicles')
 ---@type PathSwitcher
 local m_PathSwitcher = require('PathSwitcher')
 ---@type NodeCollection
@@ -28,7 +28,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 			s_TargetPosition = s_TargetPosition + (s_Forward * 50)
 			s_TargetPosition.y = s_TargetPosition.y + 50
 			local s_Waypoint = {
-				Position = s_TargetPosition
+				Position = s_TargetPosition,
 			}
 			p_Bot._TargetPoint = s_Waypoint
 			return
@@ -82,7 +82,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 		-- Execute Action if needed. 
 		if p_Bot._ActiveAction == BotActionFlags.OtherActionActive then
 			if s_Point.Data ~= nil and s_Point.Data.Action ~= nil then
-				if s_Point.Data.Action.type == "exit" then
+				if s_Point.Data.Action.type == 'exit' then
 					p_Bot:_ResetActionFlag(BotActionFlags.OtherActionActive)
 					local s_OnlyPassengers = false
 					if s_Point.Data.Action.onlyPassengers ~= nil and s_Point.Data.Action.onlyPassengers == true then
@@ -139,7 +139,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 			-- Detect obstacle and move over or around. To-do: Move before normal jump. 
 			local s_CurrentWayPointDistance = p_Bot.m_Player.controlledControllable.transform.trans:Distance(s_Point.Position)
 
-			if s_CurrentWayPointDistance > p_Bot._LastWayDistance + 0.02 and p_Bot._ObstaceSequenceTimer == 0.0 then
+			if s_CurrentWayPointDistance > p_Bot._LastWayDistance + 0.02 and p_Bot._ObstaceSequenceTimer == 0 then
 				-- Skip one point. 
 				s_DistanceFromTarget = 0
 				s_HeightDistance = 0
@@ -148,7 +148,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 			p_Bot._TargetPoint = s_Point
 			p_Bot._NextTargetPoint = s_NextPoint
 
-			if math.abs(s_CurrentWayPointDistance - p_Bot._LastWayDistance) < 0.02 or p_Bot._ObstaceSequenceTimer ~= 0.0 then
+			if math.abs(s_CurrentWayPointDistance - p_Bot._LastWayDistance) < 0.02 or p_Bot._ObstaceSequenceTimer ~= 0 then
 				-- Try to get around obstacle. 
 				if p_Bot._ObstacleRetryCounter % 2 == 0 then
 					if p_Bot._ObstaceSequenceTimer < 4.0 then
@@ -161,7 +161,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 				end
 
 				if (p_Bot.m_ActiveSpeedValue == BotMoveSpeeds.Backwards and p_Bot._ObstaceSequenceTimer > 3.0) or
-					(p_Bot.m_ActiveSpeedValue ~= BotMoveSpeeds.Backwards and p_Bot._ObstaceSequenceTimer > 5.0) then
+				(p_Bot.m_ActiveSpeedValue ~= BotMoveSpeeds.Backwards and p_Bot._ObstaceSequenceTimer > 5.0) then
 					p_Bot._ObstaceSequenceTimer = 0.0
 					p_Bot._ObstacleRetryCounter = p_Bot._ObstacleRetryCounter + 1
 				end
@@ -183,7 +183,7 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 						s_Transform.trans = p_Bot._TargetPoint.Position
 						s_Transform:LookAtTransform(p_Bot._TargetPoint.Position, p_Bot._NextTargetPoint.Position)
 						p_Bot.m_Player.controlledControllable.transform = s_Transform
-						m_Logger:Write("tepeported in vehicle of " .. p_Bot.m_Player.name)
+						m_Logger:Write('teleported in vehicle of ' .. p_Bot.m_Player.name)
 					else
 						if m_Vehicles:IsVehicleType(p_Bot.m_ActiveVehicle, VehicleTypes.Chopper) or
 							m_Vehicles:IsVehicleType(p_Bot.m_ActiveVehicle, VehicleTypes.Plane) then
@@ -200,7 +200,6 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 			end
 
 			p_Bot._LastWayDistance = s_CurrentWayPointDistance
-
 
 			local s_TargetDistanceSpeed = Config.TargetDistanceWayPoint * 5
 
@@ -574,7 +573,6 @@ function VehicleMovement:UpdateYawVehicle(p_Bot, p_Attacking, p_IsStationaryLaun
 			return
 		end
 
-
 		-- Calculate delta pitch. 
 		local s_Delta_Tilt = 0
 		local s_Current_Tilt = math.asin(p_Bot.m_Player.controlledControllable.transform.forward.y / 1.0)
@@ -640,7 +638,6 @@ function VehicleMovement:UpdateYawVehicle(p_Bot, p_Attacking, p_IsStationaryLaun
 		local s_TransformedInputYaw = math.cos(s_Current_Roll) * s_DeltaYaw + math.sin(s_Current_Roll) * s_Delta_Tilt
 		local s_TransformedInputTilt = math.cos(s_Current_Roll) * s_Delta_Tilt - math.sin(s_Current_Roll) * s_DeltaYaw
 
-
 		local s_Output_Tilt = p_Bot._Pid_Drv_Tilt:Update(s_TransformedInputTilt)
 		local s_Output_Yaw = p_Bot._Pid_Drv_Yaw:Update(s_TransformedInputYaw)
 
@@ -650,7 +647,6 @@ function VehicleMovement:UpdateYawVehicle(p_Bot, p_Attacking, p_IsStationaryLaun
 		-- YAW 
 		-- No backwards in planes. 
 		p_Bot.m_Player.input:SetLevel(EntryInputActionEnum.EIAYaw, -s_Output_Yaw)
-
 
 		-- Throttle. 
 		-- Target velocity == 313 km/h → 86.9444 m/s 

--- a/ext/Server/Database.lua
+++ b/ext/Server/Database.lua
@@ -7,7 +7,7 @@ require('__shared/ArrayMap')
 local m_Batches = ArrayMap()
 local m_Batched = ''
 ---@type Logger
-local m_Logger = Logger("Database", Debug.Server.DATABASE)
+local m_Logger = Logger('Database', Debug.Server.DATABASE)
 
 DatabaseField = {
 	NULL = '{::DB:NULL::}',
@@ -140,10 +140,10 @@ end
 function Database:ExecuteBatch()
 	self:Query('DELETE FROM `FB_Settings`')
 	self:Query(m_Batched .. m_Batches:join(', '))
-	m_Batched = ""
+	m_Batched = ''
 	m_Batches:clear()
 
-	if self:GetError() ~= "" then
+	if self:GetError() ~= '' then
 		m_Logger:Error(self:GetError())
 	end
 end
@@ -152,7 +152,6 @@ function Database:BatchQuery(p_TableName, p_Parameters, p_Where)
 	local s_Names = ArrayMap()
 	local s_Values = ArrayMap()
 	local s_Fields = ArrayMap()
-	local s_Found = nil
 
 	for l_Name, l_Value in pairs(p_Parameters) do
 		s_Names:add('`' .. l_Name .. '`')
@@ -175,10 +174,6 @@ function Database:BatchQuery(p_TableName, p_Parameters, p_Where)
 		else
 			s_Values:add('\'' .. tostring(l_Value) .. '\'')
 			l_Value = tostring(l_Value)
-		end
-
-		if p_Where == l_Name then
-			s_Found = l_Value
 		end
 
 		if p_Where ~= l_Name then

--- a/ext/Server/NodeCollection.lua
+++ b/ext/Server/NodeCollection.lua
@@ -1251,11 +1251,8 @@ function NodeCollection:ProcessAllDataToSave()
 
 		local s_QueriesTotal = #self._SaveTraceBatchQueries
 		m_Logger:Write('Save -> Saved [' .. s_QueriesTotal .. '] waypoints for map [' .. self._MapName .. ']')
-		ChatManager:Yell(
-						Language:I18N(
-										'Saved %d paths with %d waypoints for map %s', self._SavedPathCount, s_QueriesTotal, self._MapName
-						), 5.5
-		)
+		ChatManager:Yell(Language:I18N('Saved %d paths with %d waypoints for map %s', self._SavedPathCount, s_QueriesTotal, self._MapName), 
+		5.5)
 
 		self._SaveActive = false
 	end

--- a/ext/Server/NodeCollection.lua
+++ b/ext/Server/NodeCollection.lua
@@ -1,11 +1,11 @@
 ---@class NodeCollection
 ---@overload fun(p_DisableServerEvents?: boolean):NodeCollection
-NodeCollection = class "NodeCollection"
+NodeCollection = class 'NodeCollection'
 
 ---@type Utilities
 local m_Utilities = require('__shared/Utilities.lua')
 ---@type Logger
-local m_Logger = Logger("NodeCollection", Debug.Server.NODECOLLECTION)
+local m_Logger = Logger('NodeCollection', Debug.Server.NODECOLLECTION)
 
 function NodeCollection:__init(p_DisableServerEvents)
 	self:InitVars()
@@ -60,7 +60,7 @@ function NodeCollection:Create(p_Data, p_Authoritative)
 		Distance = nil, -- Current distance to player. 
 		Updated = false, -- If true, needs to be sent to server for saving. 
 		Previous = false, -- Tree navigation. 
-		Next = false
+		Next = false,
 	}
 
 	if p_Data ~= nil then
@@ -93,7 +93,7 @@ function NodeCollection:Register(p_Waypoint)
 		self._WaypointsByPathIndex[p_Waypoint.PathIndex] = {}
 	end
 
-	-- Node associations are already set, don't change them. 
+	--[[ Node associations are already set, don't change them. 
 	if p_Waypoint.Previous and p_Waypoint.Next and false then -- Disabled for now. 
 		-- Begin searching for related nodes from the tail and work backwards. 
 		for i = #self._WaypointsByPathIndex[p_Waypoint.PathIndex], 1, -1 do
@@ -112,6 +112,7 @@ function NodeCollection:Register(p_Waypoint)
 			end
 		end
 	end
+	--]] 
 
 	table.insert(self._Waypoints, p_Waypoint)
 
@@ -276,10 +277,10 @@ function NodeCollection:RecalculateIndexes(p_Waypoint)
 			s_Counter = s_Counter + 1
 		end
 	else
-		local s_Direction = "Next"
+		local s_Direction = 'Next'
 
 		if not p_Waypoint.Next then
-			s_Direction = "Previous"
+			s_Direction = 'Previous'
 		end
 
 		while p_Waypoint do
@@ -295,10 +296,8 @@ end
 ---@param p_Waypoint Waypoint
 ---@return Waypoint
 function NodeCollection:_processWaypointRecalc(p_Waypoint)
-	local s_LastIndex = 0
 	local s_LastPathIndex = 0
 	local s_LastPointIndex = 0
-	local s_CurrentPathIndex = -1
 
 	-- Convert neighbour references. 
 	if type(p_Waypoint.Next) == 'string' then
@@ -318,7 +317,6 @@ function NodeCollection:_processWaypointRecalc(p_Waypoint)
 	end
 
 	if p_Waypoint.Previous then
-		s_LastIndex = p_Waypoint.Previous.Index
 		s_LastPathIndex = p_Waypoint.Previous.PathIndex
 		s_LastPointIndex = p_Waypoint.Previous.PointIndex
 	end
@@ -376,7 +374,7 @@ function NodeCollection:_processWaypointMetadata(p_Waypoint)
 	-- <p_Waypoint_ID>, 
 	-- <p_Waypoint_ID>, 
 	-- ... 
-	--} 
+	-- } 
 
 	-- If the node has a link mode and no links, then try to find them. 
 	if p_Waypoint.Data.LinkMode ~= nil and
@@ -384,7 +382,6 @@ function NodeCollection:_processWaypointMetadata(p_Waypoint)
 		-- Indirect connections. 
 		if p_Waypoint.Data.LinkMode == 1 then
 			local s_Range = p_Waypoint.Data.Range or 3 -- Meters, box-like area. 
-			local s_Chance = p_Waypoint.Data.Chance or 25 -- 1 - 100 
 			local s_NearbyNodes = self:FindAll(p_Waypoint.Position, s_Range)
 
 			p_Waypoint.Data.Links = {}
@@ -459,7 +456,7 @@ function NodeCollection:SetInput(p_Speed, p_Extra, p_Option)
 			InputVar = s_InputVar,
 			SpeedMode = p_Speed,
 			ExtraMode = p_Extra,
-			OptValue = p_Option
+			OptValue = p_Option,
 		})
 	end
 
@@ -504,7 +501,7 @@ function NodeCollection:Link(p_SelectionId, p_Waypoints, p_LinkID, p_OneWay)
 	table.insert(s_Links, p_LinkID)
 	self:Update(s_Selection.Data, {
 		LinkMode = (s_Selection.Data.LinkMode or 0),
-		Links = s_Links
+		Links = s_Links,
 	})
 
 	if not p_OneWay then
@@ -568,7 +565,7 @@ function NodeCollection:Unlink(p_SelectionId, p_Waypoints, p_LinkID, p_OneWay)
 	if #s_NewLinks > 0 then
 		self:Update(s_Selection.Data, {
 			LinkMode = (s_Selection.Data.LinkMode or 0),
-			Links = s_NewLinks
+			Links = s_NewLinks,
 		})
 	else
 		local s_NewData = {}
@@ -582,7 +579,7 @@ function NodeCollection:Unlink(p_SelectionId, p_Waypoints, p_LinkID, p_OneWay)
 		end
 
 		self:Update(s_Selection, {
-			Data = s_NewData
+			Data = s_NewData,
 		})
 	end
 
@@ -782,11 +779,15 @@ function NodeCollection:IsSelected(p_SelectionId, p_Waypoint, p_PathIndex)
 		self._SelectedWaypoints[p_SelectionId] = {}
 	end
 
-	if p_Waypoint == nil then return false end
+	if p_Waypoint == nil then
+		return false
+	end
 
 	p_Waypoint = self:Get(p_Waypoint, p_PathIndex)
 
-	if p_Waypoint == nil then return false end
+	if p_Waypoint == nil then
+		return false
+	end
 
 	return self._SelectedWaypoints[p_SelectionId][p_Waypoint.ID] ~= nil
 end
@@ -915,7 +916,7 @@ function NodeCollection:SplitSelection(p_SelectionId)
 	for i = 1, #s_Selection - 1 do
 		local s_NewWaypoint = self:Create({
 			Position = ((s_Selection[i].Position + s_Selection[i + 1].Position) / 2),
-			PathIndex = s_Selection[i].PathIndex
+			PathIndex = s_Selection[i].PathIndex,
 		})
 
 		self:Select(p_SelectionId, s_NewWaypoint)
@@ -951,7 +952,7 @@ function NodeCollection:Load(p_LevelName, p_GameMode)
 
 	if p_GameMode ~= nil and p_LevelName ~= nil then
 		self._MapName = p_LevelName .. '_' .. p_GameMode
-		self._MapName = self._MapName:gsub(" ", "_")
+		self._MapName = self._MapName:gsub(' ', '_')
 	end
 
 	if self._MapName == '' or self._MapName == nil then
@@ -984,7 +985,6 @@ function NodeCollection:Load(p_LevelName, p_GameMode)
 		return
 	end
 
-
 	-- Fetch all rows from the table. 
 	local s_Results = SQL:Query('SELECT * FROM ' .. self._MapName .. '_table ORDER BY pathIndex, pointIndex ASC')
 
@@ -1001,21 +1001,21 @@ function NodeCollection:Load(p_LevelName, p_GameMode)
 	local s_LastPathindex = -1
 
 	for _, l_Row in pairs(s_Results) do
-		if l_Row["pathIndex"] ~= s_LastPathindex then
+		if l_Row['pathIndex'] ~= s_LastPathindex then
 			s_PathCount = s_PathCount + 1
-			s_LastPathindex = l_Row["pathIndex"]
+			s_LastPathindex = l_Row['pathIndex']
 		end
 
 		local s_Waypoint = {
-			OriginalID = l_Row["id"],
-			Position = Vec3(l_Row["transX"], l_Row["transY"], l_Row["transZ"]),
-			PathIndex = l_Row["pathIndex"],
-			PointIndex = l_Row["pointIndex"],
-			InputVar = l_Row["inputVar"],
-			SpeedMode = l_Row["inputVar"] & 0xF,
-			ExtraMode = (l_Row["inputVar"] >> 4) & 0xF,
-			OptValue = (l_Row["inputVar"] >> 8) & 0xFF,
-			Data = json.decode(l_Row["data"] or '{}')
+			OriginalID = l_Row['id'],
+			Position = Vec3(l_Row['transX'], l_Row['transY'], l_Row['transZ']),
+			PathIndex = l_Row['pathIndex'],
+			PointIndex = l_Row['pointIndex'],
+			InputVar = l_Row['inputVar'],
+			SpeedMode = l_Row['inputVar'] & 0xF,
+			ExtraMode = (l_Row['inputVar'] >> 4) & 0xF,
+			OptValue = (l_Row['inputVar'] >> 8) & 0xFF,
+			Data = json.decode(l_Row['data'] or '{}'),
 		}
 
 		if s_FirstWaypoint == nil then
@@ -1101,7 +1101,7 @@ function NodeCollection:ProcessAllDataToSave()
 							local s_LinkedWaypoint = self:Get(l_Waypoint.Data.Links[i])
 
 							if s_LinkedWaypoint ~= nil then
-								table.insert(s_ConvertedLinks, { s_LinkedWaypoint.PathIndex, s_LinkedWaypoint.PointIndex })
+								table.insert(s_ConvertedLinks, {s_LinkedWaypoint.PathIndex, s_LinkedWaypoint.PointIndex})
 							end
 						end
 
@@ -1153,7 +1153,7 @@ function NodeCollection:ProcessAllDataToSave()
 		self._SaveTraceQueriesDone = 0
 		self._InsertQuery = 'INSERT INTO ' ..
 			self._MapName .. '_table (pathIndex, pointIndex, transX, transY, transZ, inputVar, data) VALUES '
-		self._Values = ""
+		self._Values = ''
 
 	elseif self._SaveStateMachineCounter == 2 then
 		local s_QueriesTotal = #self._SaveTraceBatchQueries
@@ -1162,7 +1162,7 @@ function NodeCollection:ProcessAllDataToSave()
 			local s_StringLenght = #self._InsertQuery
 			local s_QueryCount = 0
 
-			if self._Values == "" then
+			if self._Values == '' then
 				self._Values = self._SaveTraceBatchQueries[self._SaveTraceQueriesDone + 1]
 				self._SaveTraceQueriesDone = self._SaveTraceQueriesDone + 1
 			end
@@ -1181,7 +1181,7 @@ function NodeCollection:ProcessAllDataToSave()
 
 			table.insert(self._SaveTracesQueryStrings, self._InsertQuery .. self._Values)
 
-			self._Values = ""
+			self._Values = ''
 
 			return -- Do this again. 
 		end
@@ -1251,9 +1251,11 @@ function NodeCollection:ProcessAllDataToSave()
 
 		local s_QueriesTotal = #self._SaveTraceBatchQueries
 		m_Logger:Write('Save -> Saved [' .. s_QueriesTotal .. '] waypoints for map [' .. self._MapName .. ']')
-		ChatManager:Yell(Language:I18N('Saved %d paths with %d waypoints for map %s', self._SavedPathCount, s_QueriesTotal,
-			self._MapName)
-			, 5.5)
+		ChatManager:Yell(
+						Language:I18N(
+										'Saved %d paths with %d waypoints for map %s', self._SavedPathCount, s_QueriesTotal, self._MapName
+						), 5.5
+		)
 
 		self._SaveActive = false
 	end
@@ -1316,8 +1318,9 @@ function NodeCollection:ObjectiveDirection(p_Waypoint, p_Objective, p_InVehicle)
 					local s_Link = self:Get(l_LinkID)
 					local s_PathWaypoint = self:GetFirst(s_Link.PathIndex)
 
-					if s_PathWaypoint ~= nil and s_PathWaypoint.Data.Objectives ~= nil and
-						table.has(s_PathWaypoint.Data.Objectives, p_Objective) then
+					if s_PathWaypoint ~= nil and 
+					s_PathWaypoint.Data.Objectives ~= nil and
+					table.has(s_PathWaypoint.Data.Objectives, p_Objective) then
 						-- Highest priority path found, return now. 
 						if #s_PathWaypoint.Data.Objectives == 1 then
 							return s_Direction, s_CurrentWaypoint[s_Direction]
@@ -1338,7 +1341,7 @@ function NodeCollection:ObjectiveDirection(p_Waypoint, p_Objective, p_InVehicle)
 
 	if s_BestDirection == nil then
 		if not p_InVehicle then
-			local s_Directions = { 'Next', 'Previous' }
+			local s_Directions = {'Next', 'Previous'}
 			s_BestDirection = s_Directions[MathUtils:GetRandomInt(1, 2)]
 		else
 			s_BestDirection = 'Next'

--- a/ext/Server/NodeEditor.lua
+++ b/ext/Server/NodeEditor.lua
@@ -1,11 +1,11 @@
 ---@class NodeEditor
 ---@overload fun():NodeEditor
-NodeEditor = class "NodeEditor"
+NodeEditor = class('NodeEditor')
 
 ---@type NodeCollection
 local m_NodeCollection = require('NodeCollection')
 ---@type Logger
-local m_Logger = Logger("NodeEditor", Debug.Server.NODEEDITOR)
+local m_Logger = Logger('NodeEditor', Debug.Server.NODEEDITOR)
 
 function NodeEditor:__init()
 	self.m_ActiveTracePlayers = {}
@@ -27,7 +27,6 @@ function NodeEditor:RegisterCustomEvents()
 
 	-- Remove them? 
 	-- NetEvents:Subscribe('UI_Request_Save_Settings', self, self.OnUIRequestSaveSettings) 
-
 
 	-- EDIT-Events from Client. 
 	NetEvents:Subscribe('NodeEditor:Select', self, self.OnSelect)
@@ -54,7 +53,6 @@ function NodeEditor:RegisterCustomEvents()
 	NetEvents:Subscribe('NodeEditor:SpawnBot', self, self.OnSpawnBot)
 	NetEvents:Subscribe('NodeEditor:UpdatePos', self, self.OnUpdatePos)
 	NetEvents:Subscribe('NodeEditor:AddNode', self, self.OnAddNode)
-
 
 	-- To-do: fill. 
 end
@@ -90,7 +88,7 @@ function NodeEditor:OnUpdatePos(p_Player, p_UpdateData)
 	for _, l_UpdateItem in pairs(p_UpdateData) do
 		local s_NodeToUpdate = m_NodeCollection:Get(l_UpdateItem.ID)
 		m_NodeCollection:Update(s_NodeToUpdate, {
-			Position = l_UpdateItem.Pos
+			Position = l_UpdateItem.Pos,
 		})
 	end
 end
@@ -113,11 +111,11 @@ function NodeEditor:OnAddMcom(p_Player)
 
 	for i = 1, #s_Selection do
 		local action = {
-			type = "mcom",
-			inputs = { EntryInputActionEnum.EIAInteract },
+			type = 'mcom',
+			inputs = {EntryInputActionEnum.EIAInteract},
 			time = 6.0,
 			yaw = p_Player.input.authoritativeAimingYaw,
-			pitch = p_Player.input.authoritativeAimingPitch
+			pitch = p_Player.input.authoritativeAimingPitch,
 		}
 		s_Selection[i].Data.Action = action
 		self:Log(p_Player, 'Updated Waypoint: %s', s_Selection[i].ID)
@@ -144,11 +142,11 @@ function NodeEditor:OnAddVehicle(p_Player)
 
 	for i = 1, #s_Selection do
 		local action = {
-			type = "vehicle",
-			inputs = { EntryInputActionEnum.EIAInteract },
+			type = 'vehicle',
+			inputs = {EntryInputActionEnum.EIAInteract},
 			time = 0.5,
 			yaw = p_Player.input.authoritativeAimingYaw,
-			pitch = p_Player.input.authoritativeAimingPitch
+			pitch = p_Player.input.authoritativeAimingPitch,
 		}
 		s_Selection[i].Data.Action = action
 		self:Log(p_Player, 'Updated Waypoint: %s', s_Selection[i].ID)
@@ -172,18 +170,18 @@ function NodeEditor:OnExitVehicle(p_Player, p_Args)
 		return
 	end
 
-	local s_Data = p_Args[1] or "false"
+	local s_Data = p_Args[1] or 'false'
 	self:Log(p_Player, 'Exit Vehicle (type): %s', g_Utilities:dump(s_Data, true))
 
-	local s_OnlyPassengers = not (s_Data:lower() == "false" or s_Data == "0")
+	local s_OnlyPassengers = not (s_Data:lower() == 'false' or s_Data == '0')
 	print(s_OnlyPassengers)
 
 	for i = 1, #s_Selection do
 		local action = {
-			type = "exit",
+			type = 'exit',
 			onlyPassengers = s_OnlyPassengers,
-			inputs = { EntryInputActionEnum.EIAInteract },
-			time = 0.5
+			inputs = {EntryInputActionEnum.EIAInteract},
+			time = 0.5,
 		}
 		s_Selection[i].Data.Action = action
 		self:Log(p_Player, 'Updated Waypoint: %s', s_Selection[i].ID)
@@ -193,7 +191,7 @@ function NodeEditor:OnExitVehicle(p_Player, p_Args)
 end
 
 function NodeEditor:OnAddVehiclePath(p_Player, p_Args)
-	local s_Data = table.concat(p_Args or { "land" }, ' ')
+	local s_Data = table.concat(p_Args or {'land'}, ' ')
 	self:Log(p_Player, 'Add Vehicle (type): %s', g_Utilities:dump(s_Data, true))
 
 	local s_Selection = m_NodeCollection:GetSelected(p_Player.onlineId)
@@ -472,13 +470,11 @@ function NodeEditor:OnCloseEditor(p_Player)
 	self.m_ActiveTracePlayers[p_Player.onlineId] = false
 end
 
-
 -- ============================================= 
 -- Trace Events 
 -- Trace Recording 
 -- ============================================= 
 function NodeEditor:_getNewIndex()
-	local s_NextIndex = 0
 	local s_AllPaths = m_NodeCollection:GetPaths()
 
 	local s_HighestIndex = 0
@@ -532,7 +528,7 @@ function NodeEditor:StartTrace(p_Player)
 	end
 
 	local s_FirstWaypoint = self.m_CustomTrace[p_Player.onlineId]:Create({
-		Position = s_PlayerPos
+		Position = s_PlayerPos,
 	})
 	self.m_CustomTrace[p_Player.onlineId]:ClearSelection()
 	self.m_CustomTrace[p_Player.onlineId]:Select(nil, s_FirstWaypoint)
@@ -542,13 +538,13 @@ function NodeEditor:StartTrace(p_Player)
 	local s_TotalTraceDistance = self.m_CustomTraceDistance[p_Player.onlineId]
 	local s_TotalTraceNodes = #self.m_CustomTrace[p_Player.onlineId]:Get()
 	local s_TraceIndex = self.m_CustomTraceIndex[p_Player.onlineId] -- To-do: not really needed? 
-	NetEvents:SendToLocal("UI_ClientNodeEditor_TraceData", p_Player, s_TotalTraceNodes, s_TotalTraceDistance, s_TraceIndex,
+	NetEvents:SendToLocal('UI_ClientNodeEditor_TraceData', p_Player, s_TotalTraceNodes, s_TotalTraceDistance, s_TraceIndex,
 		true)
 end
 
 function NodeEditor:EndTrace(p_Player)
 	self.m_CustomTraceTimer[p_Player.onlineId] = -1
-	NetEvents:SendToLocal("UI_ClientNodeEditor_TraceData", p_Player, nil, nil, nil, false)
+	NetEvents:SendToLocal('UI_ClientNodeEditor_TraceData', p_Player, nil, nil, nil, false)
 
 	local s_FirstWaypoint = self.m_CustomTrace[p_Player.onlineId]:GetFirst()
 
@@ -602,8 +598,7 @@ function NodeEditor:ClearTrace(p_Player)
 		local s_TotalTraceDistance = self.m_CustomTraceDistance[p_Player.onlineId]
 		local s_TotalTraceNodes = #self.m_CustomTrace[p_Player.onlineId]:Get()
 		local s_TraceIndex = self.m_CustomTraceIndex[p_Player.onlineId] -- To-do: not really needed ? 
-		NetEvents:SendToLocal("UI_ClientNodeEditor_TraceData", p_Player, s_TotalTraceNodes, s_TotalTraceDistance, s_TraceIndex
-			,
+		NetEvents:SendToLocal('UI_ClientNodeEditor_TraceData', p_Player, s_TotalTraceNodes, s_TotalTraceDistance, s_TraceIndex,
 			false)
 
 		self:Log(p_Player, 'Custom Trace Cleared')
@@ -741,12 +736,12 @@ function NodeEditor:OnLevelLoaded(p_LevelName, p_GameMode)
 		p_GameMode = 'TeamDeathMatch0' -- Paths are compatible. 
 	end
 
-	if p_LevelName == "MP_Subway" and p_GameMode == "ConquestSmall0" then
-		p_GameMode = "ConquestLarge0" -- Paths are the same. 
+	if p_LevelName == 'MP_Subway' and p_GameMode == 'ConquestSmall0' then
+		p_GameMode = 'ConquestLarge0' -- Paths are the same. 
 	end
 
-	if p_LevelName == "XP4_Rubble" and p_GameMode == "ConquestAssaultLarge0" then
-		p_GameMode = "ConquestAssaultSmall0"
+	if p_LevelName == 'XP4_Rubble' and p_GameMode == 'ConquestAssaultLarge0' then
+		p_GameMode = 'ConquestAssaultSmall0'
 	end
 
 	m_NodeCollection:Load(p_LevelName, p_GameMode)
@@ -848,7 +843,7 @@ function NodeEditor:OnEngineUpdate(p_DeltaTime, p_SimulationDeltaTime)
 						if s_Player.soldier.weaponsComponent.currentWeaponSlot == WeaponSlot.WeaponSlot_0 then
 							local s_NewWaypoint, s_Msg = self.m_CustomTrace[l_PlayerGuid]:Add()
 							self.m_CustomTrace[l_PlayerGuid]:Update(s_NewWaypoint, {
-								Position = s_PlayerPos
+								Position = s_PlayerPos,
 							})
 							self.m_CustomTrace[l_PlayerGuid]:ClearSelection()
 							self.m_CustomTrace[l_PlayerGuid]:Select(nil, s_NewWaypoint)
@@ -909,7 +904,7 @@ function NodeEditor:OnEngineUpdate(p_DeltaTime, p_SimulationDeltaTime)
 						-- To-do: Send to Client UI. 
 						local s_TotalTraceDistance = self.m_CustomTraceDistance[l_PlayerGuid]
 						local s_TotalTraceNodes = #self.m_CustomTrace[l_PlayerGuid]:Get()
-						NetEvents:SendUnreliableToLocal("UI_ClientNodeEditor_TraceData", s_Player, s_TotalTraceNodes, s_TotalTraceDistance)
+						NetEvents:SendUnreliableToLocal('UI_ClientNodeEditor_TraceData', s_Player, s_TotalTraceNodes, s_TotalTraceDistance)
 					end
 				else
 					-- Collection is empty, stop the timer. 
@@ -920,7 +915,6 @@ function NodeEditor:OnEngineUpdate(p_DeltaTime, p_SimulationDeltaTime)
 			end
 		end
 	end
-
 
 	-- Visible NODE distribution-handling. 
 	if self.m_NodeSendUpdateTimer < 0.1 then
@@ -998,7 +992,7 @@ function NodeEditor:OnEngineUpdate(p_DeltaTime, p_SimulationDeltaTime)
 									Links = {},
 									NextPos = nil,
 									IsTrace = false,
-									IsOthersTrace = false
+									IsOthersTrace = false,
 								}
 
 								-- Fill tables. 
@@ -1083,7 +1077,7 @@ function NodeEditor:OnEngineUpdate(p_DeltaTime, p_SimulationDeltaTime)
 							IsSelected = s_IsSelected,
 							NextPos = nil,
 							IsTrace = true,
-							IsOthersTrace = false
+							IsOthersTrace = false,
 						}
 
 						-- Fill tables. 


### PR DESCRIPTION
This PR removes the unused locals `s_IsOtherTracePath`, `s_NextIndex`, `s_LastIndex`, `s_CurrentPathIndex`, `s_Chance`, `s_Found` and an `m_Logger` object. Also, due to their [rounding errors](https://floating-point-gui.de/errors/comparison/), it's better to avoid comparations (`==` and `~=`) between float numbers, so it fixes this. Double quotes were replaced by single quotes, as an attempt to standardize string representation in these files. It fixes a typo in the `m_Logger` in `BotMovement.lua`. Finally, it comments an if statement that's not being used in `NodeCollection.lua`, this statement is disabled since it's always false.