### PR TITLE
Change target waypoint distance for air vehicles

### DIFF
--- a/ext/Server/Bot/VehicleMovement.lua
+++ b/ext/Server/Bot/VehicleMovement.lua
@@ -205,6 +205,10 @@ function VehicleMovement:UpdateNormalMovementVehicle(p_Bot)
 
 			local s_TargetDistanceSpeed = Config.TargetDistanceWayPoint * 5
 
+			if m_Vehicles:IsAirVehicle(p_Bot.m_ActiveVehicle) then
+				s_TargetDistanceSpeed = Config.TargetDistanceWayPointAirVehicles
+			end
+
 			if p_Bot.m_ActiveSpeedValue == BotMoveSpeeds.Sprint then
 				s_TargetDistanceSpeed = s_TargetDistanceSpeed * 6
 			elseif p_Bot.m_ActiveSpeedValue == BotMoveSpeeds.SlowCrouch then

--- a/ext/Shared/Config.lua
+++ b/ext/Shared/Config.lua
@@ -149,6 +149,7 @@ Config = {
 	BotVehicleFireModeDuration = 9.0,	-- The minimum time a bot tries to shoot a player or vehicle, when in a vehicle - recommended minimum 7.0 
 	MaximunYawPerSec = 450,				-- In Degrees. Rotation Movement per second 
 	TargetDistanceWayPoint = 0.8,		-- The distance the bots have to reach to continue with the next Waypoint 
+	TargetDistanceWayPointAirVehicles = 16.0,    -- The distance the bots have to reach to continue with the next Waypoint on air vehicles
 	KeepOneSlotForPlayers = true,		-- Always keep one slot for free new Players to join 
 	DistanceToSpawnBots = 30,			-- Distance to spawn Bots away from players 
 	HeightDistanceToSpawn = 2.8,		-- Distance vertically, Bots should spawn away, if closer than distance 

--- a/ext/Shared/Settings/SettingsDefinition.lua
+++ b/ext/Shared/Settings/SettingsDefinition.lua
@@ -1523,6 +1523,18 @@ SettingsDefinition = {
 			Category = "EXPERT"
 		},
 		{
+			Name = "TargetDistanceWayPointAirVehicles",
+			Text = "Target distance waypoint air vehicles",
+			---@type Type|integer
+			Type = Type.Float,
+			Value = Config.TargetDistanceWayPointAirVehicles,
+			Description = "The distance the bots have to reach to continue with the next Waypoint on air vehicles",
+			Reference = Range(0.00, 100.00, 0.10),
+			Default = 16.0,
+			UpdateFlag = UpdateFlag.None,
+			Category = "EXPERT"
+		},
+		{
 			Name = "KeepOneSlotForPlayers",
 			Text = "Keep one slot for players",
 			---@type Type|integer


### PR DESCRIPTION
The radius is too small for air vehicles, it causes them to do 180 in place to register that they have arrived at waypoint.