### PR TITLE
Navigation fixes

### DIFF
--- a/ext/Server/GameDirector.lua
+++ b/ext/Server/GameDirector.lua
@@ -829,7 +829,7 @@ function GameDirector:GetSpawnPath(p_TeamId, p_SquadId, p_OnlyBase)
 
 			local s_Node = m_NodeCollection:Get(1, l_Path)
 
-			if s_Node == nil or s_Node.Data.Objectives == nil or #s_Node.Data.Objectives ~= 1 then
+			if s_Node == nil or s_Node.Data.Objectives == nil or #s_Node.Data.Objectives ~= 1 or s_Node.Data.Vehicles ~= nil then
 				goto continue_paths_loop
 			end
 

--- a/ext/Server/GameDirector.lua
+++ b/ext/Server/GameDirector.lua
@@ -945,7 +945,7 @@ function GameDirector:IsBasePath(p_ObjectiveNames)
 	for _, l_ObjectiveName in pairs(p_ObjectiveNames) do
 		local s_Objective = self:_GetObjectiveObject(l_ObjectiveName)
 
-		if s_Objective ~= nil and s_Objective.isBase then
+		if #p_ObjectiveNames == 1 and s_Objective ~= nil and s_Objective.isBase then
 			return true
 		end
 	end

--- a/ext/Server/PathSwitcher.lua
+++ b/ext/Server/PathSwitcher.lua
@@ -156,6 +156,14 @@ function PathSwitcher:GetNewPath(p_Bot, p_BotName, p_Point, p_Objective, p_InVeh
 						if s_NewPoint.ID == p_Point.ID then
 							s_CurrentPriority = 1
 						end
+					-- Consider path with other objective, in case everything else fails
+					elseif #s_PathNode.Data.Objectives == 1 then
+						table.insert(s_Paths, {
+							Priority = 0,
+							Point = s_NewPoint,
+							State = s_NewPathStatus,
+							Base = s_NewBasePath
+						})
 					end
 				end
 			end


### PR DESCRIPTION
Some things I fixed when I was making traces.

1. When bots were trying to get from the base to an objective that was far away they were killed by timeout. It's a problem for large maps like Death Valley, because first objectives are really far away and not all bots were taking vehicles. So I changed to killing them only if they are stuck on the base path only, and not on paths that connect the base with the objectives.
2. I created single objective paths for vehicles and bots started to spawn on them. Fixed it.
3. Sometimes bots get stuck between two objectives if their assigned objective is different from those two. Let bots consider to switch to either one of those objectives and since every objective should be connected to every other objective, they will find the path to their assigned objective.