### PR TITLE
Fix for the issue where the bots were switching teams 

### DIFF
--- a/ext/Server/BotSpawner.lua
+++ b/ext/Server/BotSpawner.lua
@@ -1939,7 +1939,9 @@ function BotSpawner:_SwitchTeams()
 				s_NewTeam = Globals.NrOfTeams
 			end
 
-			l_Player.teamId = s_NewTeam
+			if not Config.BotTeamNames or m_Utilities:isBot(l_Player) then
+				l_Player.teamId = s_NewTeam
+			end
 		end
 	end
 end


### PR DESCRIPTION
Fix for the issue where the bots were switching teams when starting the second round in the same map, now they no longer switch keeping consistency of the names setted per team :)