### PR TITLE
Passengers exit vehicles if they are near any objective (50 m)

### DIFF
--- a/ext/Server/Bot.lua
+++ b/ext/Server/Bot.lua
@@ -694,6 +694,8 @@ function Bot:_CheckForVehicleActions(p_DeltaTime, p_AttackActive)
 		end
 	end
 
+	self:_CheckShouldExitVehicleIfPassenger()
+
 	local s_VehicleEntity = self.m_Player.controlledControllable
 	if not s_VehicleEntity then
 		return
@@ -756,6 +758,39 @@ function Bot:_CheckForVehicleActions(p_DeltaTime, p_AttackActive)
 					end
 				end
 			end
+		end
+	end
+end
+
+function Bot:_CheckShouldExitVehicleIfPassenger()
+	local s_VehicleEntity = self.m_Player.controlledControllable
+	if not s_VehicleEntity then
+		return
+	end
+
+	if not self._ExitVehicleActive
+		and m_Vehicles:IsPassengerSeat(self.m_ActiveVehicle, self.m_Player.controlledEntryId)
+	then
+		local s_ShouldExit = false
+		local s_ExitDistance = Registry.BOT.PASSENGER_EXIT_DISTANCE
+		local s_AllCapturePoints = g_GameDirector:GetAllCapturePoints()
+		local s_CurrentPosition = self.m_Player.soldier.worldTransform.trans:Clone()
+		s_CurrentPosition.y = 0
+
+		for l_Index = 1, #s_AllCapturePoints do
+			local l_CapturePoint = s_AllCapturePoints[l_Index]
+			local s_Position = l_CapturePoint.transform.trans:Clone()
+			s_Position.y = 0
+
+			if s_Position:Distance(s_CurrentPosition) < s_ExitDistance then
+				s_ShouldExit = true
+				break
+			end
+		end
+
+		if s_ShouldExit then
+			self:AbortAttack()
+			self:ExitVehicle()
 		end
 	end
 end

--- a/ext/Server/GameDirector.lua
+++ b/ext/Server/GameDirector.lua
@@ -896,6 +896,10 @@ function GameDirector:GetGunshipObjectiveName(p_LevelName, p_GameMode)
 	return nil
 end
 
+function GameDirector:GetAllCapturePoints()
+	return self._AllCapturePoints
+end
+
 ---@param p_Point table
 ---@param p_TeamId TeamId|integer
 ---@param p_InVehicle boolean

--- a/ext/Server/GameDirector.lua
+++ b/ext/Server/GameDirector.lua
@@ -37,7 +37,7 @@ function GameDirector:RegisterVars()
 	self.m_MapCompletelyLoaded = false
 	self.m_SpawnedEntitiesToProcess = {}
 
-	self._AllCaptuerPoints = {}
+	self._AllCapturePoints = {}
 	self._McomPositions = {}
 end
 
@@ -657,12 +657,12 @@ function GameDirector:OnVehicleSpawnDone(p_Entity)
 	-- spawn directly into jets
 	if m_Vehicles:IsVehicleType(s_VehicleData, VehicleTypes.Plane) then
 		-- find closest spawn --> team of jet
-		if self._AllCaptuerPoints then
+		if self._AllCapturePoints then
 			local s_ClosestDistance = nil
 			local s_ClosestTeam = nil
 
-			for l_Index = 1, #self._AllCaptuerPoints do
-				local l_CapturePoint = self._AllCaptuerPoints[l_Index]
+			for l_Index = 1, #self._AllCapturePoints do
+				local l_CapturePoint = self._AllCapturePoints[l_Index]
 				if l_CapturePoint.team ~= TeamId.TeamNeutral then
 					local s_Distance = l_CapturePoint.transform.trans:Distance(p_Entity.transform.trans)
 					if s_ClosestDistance == nil or s_ClosestDistance > s_Distance then
@@ -1530,8 +1530,8 @@ function GameDirector:GetActiveTargetPointPosition(p_TeamId)
 		local s_NeutralNode = nil
 		local s_EnemyNode = nil
 		local s_FriendlyNode = nil
-		for l_Index = 1, #self._AllCaptuerPoints do
-			local l_CapturePoint = self._AllCaptuerPoints[l_Index]
+		for l_Index = 1, #self._AllCapturePoints do
+			local l_CapturePoint = self._AllCapturePoints[l_Index]
 
 			local s_Pos = l_CapturePoint.transform.trans
 			if l_CapturePoint.team ~= p_TeamId then
@@ -1709,7 +1709,7 @@ function GameDirector:_InitObjectives()
 end
 
 function GameDirector:_InitFlagTeams()
-	self._AllCaptuerPoints = {}
+	self._AllCapturePoints = {}
 	if not Globals.IsConquest then -- Valid for all Conquest-types. TODO: check for rush?
 		return
 	end
@@ -1722,15 +1722,15 @@ function GameDirector:_InitFlagTeams()
 		s_Entity = CapturePointEntity(s_Entity)
 
 		if string.sub(s_Entity.name, -2) ~= "HQ" then
-			self._AllCaptuerPoints[#self._AllCaptuerPoints + 1] = s_Entity
+			self._AllCapturePoints[#self._AllCapturePoints + 1] = s_Entity
 			print(s_Entity.name)
 		end
 
 		s_Entity = s_Iterator:Next()
 	end
 
-	for l_Index = 1, #self._AllCaptuerPoints do
-		local s_Entity = self._AllCaptuerPoints[l_Index]
+	for l_Index = 1, #self._AllCapturePoints do
+		local s_Entity = self._AllCapturePoints[l_Index]
 
 		local s_ObjectiveName = self:_TranslateObjective(s_Entity.transform.trans, s_Entity.name)
 		if s_ObjectiveName ~= "" then

--- a/ext/Server/GameDirector.lua
+++ b/ext/Server/GameDirector.lua
@@ -37,7 +37,6 @@ function GameDirector:RegisterVars()
 	self.m_MapCompletelyLoaded = false
 	self.m_SpawnedEntitiesToProcess = {}
 
-	self._MidMapPoint = nil
 	self._AllCaptuerPoints = {}
 	self._McomPositions = {}
 end
@@ -1534,17 +1533,15 @@ function GameDirector:GetActiveTargetPointPosition(p_TeamId)
 		for l_Index = 1, #self._AllCaptuerPoints do
 			local l_CapturePoint = self._AllCaptuerPoints[l_Index]
 
-			if string.sub(l_CapturePoint.name, -2) ~= "HQ" then
-				local s_Pos = l_CapturePoint.transform.trans
-				if l_CapturePoint.team ~= p_TeamId then
-					s_NeutralNode = s_Pos
-				end
-				if l_CapturePoint.team == p_TeamId then
-					s_FriendlyNode = s_Pos
-				end
-				if l_CapturePoint.team == TeamId.TeamNeutral then
-					s_NeutralNode = s_Pos
-				end
+			local s_Pos = l_CapturePoint.transform.trans
+			if l_CapturePoint.team ~= p_TeamId then
+				s_NeutralNode = s_Pos
+			end
+			if l_CapturePoint.team == p_TeamId then
+				s_FriendlyNode = s_Pos
+			end
+			if l_CapturePoint.team == TeamId.TeamNeutral then
+				s_NeutralNode = s_Pos
 			end
 		end
 		-- first use enemy-nodes, then neutral, then friendly
@@ -1713,7 +1710,6 @@ end
 
 function GameDirector:_InitFlagTeams()
 	self._AllCaptuerPoints = {}
-	self._MidMapPoint = Vec3.zero
 	if not Globals.IsConquest then -- Valid for all Conquest-types. TODO: check for rush?
 		return
 	end
@@ -1724,22 +1720,19 @@ function GameDirector:_InitFlagTeams()
 
 	while s_Entity ~= nil do
 		s_Entity = CapturePointEntity(s_Entity)
-		self._AllCaptuerPoints[#self._AllCaptuerPoints + 1] = s_Entity
-		print(s_Entity.name)
+
+		if string.sub(s_Entity.name, -2) ~= "HQ" then
+			self._AllCaptuerPoints[#self._AllCaptuerPoints + 1] = s_Entity
+			print(s_Entity.name)
+		end
 
 		s_Entity = s_Iterator:Next()
 	end
-	for l_Index = 1, #self._AllCaptuerPoints do
-		local s_Entity = self._AllCaptuerPoints[l_Index]
-		self._MidMapPoint = self._MidMapPoint + s_Entity.transform.trans
-	end
-	self._MidMapPoint = self._MidMapPoint / #self._AllCaptuerPoints
 
 	for l_Index = 1, #self._AllCaptuerPoints do
 		local s_Entity = self._AllCaptuerPoints[l_Index]
 
 		local s_ObjectiveName = self:_TranslateObjective(s_Entity.transform.trans, s_Entity.name)
-		self._AllCaptuerPoints[#self._AllCaptuerPoints + 1] = s_Entity
 		if s_ObjectiveName ~= "" then
 			local s_Objective = self:_GetObjectiveObject(s_ObjectiveName)
 

--- a/ext/Shared/Constants/VehicleData.lua
+++ b/ext/Shared/Constants/VehicleData.lua
@@ -406,6 +406,7 @@ VehicleData = {
 		Parts = { { -2, -2 }, { 14, 14 } },
 		Speed = { { 300, 10000 }, { 600, 999 } },
 		Drop = { { 0.0, 0.0 }, { 0.0, 0.0 } },
+		FirstPassengerSeat = 3,
 		Offset = { { Vec3(3.374, 0.258, 1.802), Vec3(3.374, 0.258, 1.802) }, { Vec3(0.0, 0.0, 0.345), Vec3(0.0, 0.0, 0.345) } }
 	},
 	["AH1Z_coop"] = {
@@ -415,6 +416,7 @@ VehicleData = {
 		Parts = { { -2, -2 }, { 14, 14 } },
 		Speed = { { 300, 10000 }, { 600, 999 } },
 		Drop = { { 0.0, 0.0 }, { 0.0, 0.0 } },
+		FirstPassengerSeat = 3,
 		Offset = { { Vec3(3.374, 0.258, 1.802), Vec3(3.374, 0.258, 1.802) }, { Vec3(0.0, 0.0, 0.345), Vec3(0.0, 0.0, 0.345) } }
 	},
 	["AH6_Littlebird"] = {
@@ -451,6 +453,7 @@ VehicleData = {
 		Parts = { { -2, -2 }, { 6, 6 } },
 		Speed = { { 300, 10000 }, { 600, 999 } },
 		Drop = { { 0.0, 0.0 }, { 0.0, 0.0 } },
+		FirstPassengerSeat = 3,
 		Offset = { { Vec3(0.006, 0.499, 1.427), Vec3(0.006, 0.499, 1.427) }, { Vec3(0, -0.018, 0.427), Vec3(0, -0.018, 0.427) } }
 	},
 	["Venom"] = {
@@ -560,6 +563,7 @@ VehicleData = {
 		Parts = { -1, { 1, 3 }, { 0, 2 } },
 		Speed = { 300, { 600, 900 }, { 250, 900 } },
 		Drop = { 0.0, { 0.0, 0.0 }, { 0.0, 0.0 } },
+		FirstPassengerSeat = 3,
 		RotationOffset = { Vec3(0, 0, 0), { Vec3(math.pi / 2, 0.52, 0), Vec3(math.pi / 2, 0, 0) }, { Vec3(math.pi / 2, 0.375, 0), Vec3(math.pi / 2, 0, 0) } } -- use yaw and pitch as offset here
 	},
 	-- AA Stationary.

--- a/ext/Shared/Registry/Registry.lua
+++ b/ext/Shared/Registry/Registry.lua
@@ -185,6 +185,8 @@ Registry = {
 		NUMBER_NODES_TO_SCAN_AFTER_ATTACK = 20,
 		-- Delay on destroying several bots
 		BOT_DESTORY_DELAY = 0.05,
+		-- Distance to closest objective on which passengers should exit vehicles
+		PASSENGER_EXIT_DISTANCE = 50,
 	},
 	-- Bot team balancing (only in keep_playercount - spawn-mode)
 	BOT_TEAM_BALANCING = {


### PR DESCRIPTION
1. Exclude bases from objectives. Same thing as before, but now in the right place.
2. Fix typos, remove dead code. Remove duplication of objectives in _AllCaptureObjectives.
3. Check if the bot should exit the vehicle. I'll use that for mobile spawn vehicles like transport heli and amtrac in the future.