### PR TITLE
Make angle normalisation more robust

### DIFF
--- a/ext/Server/Bot/BotActions.lua
+++ b/ext/Server/Bot/BotActions.lua
@@ -173,9 +173,9 @@ function Bot:ShootAt(p_Player, p_IgnoreYaw)
 
 		-- Compute the pitch and yaw between the bot and its target. These
 		-- angles are relative to the absolute coordinate system; pitch is
-		-- measured from the x-z plane while yaw is measured from the x axis.
+		-- measured from the x-z plane while yaw is measured from the z axis.
 		local s_Pitch = math.atan(s_Vector.y, math.sqrt(s_Vector.x ^ 2 + s_Vector.z ^ 2))
-		local s_Yaw = math.atan(s_Vector.z, s_Vector.x) - (math.pi / 2) -- alignment to authoritativeAimingYaw needed (-pi/2)
+		local s_Yaw = -math.atan(s_Vector.x, s_Vector.z)
 
 		-- Transform the pitch and yaw to be relative to the bot's current
 		-- heading.

--- a/ext/Shared/Utilities.lua
+++ b/ext/Shared/Utilities.lua
@@ -173,10 +173,13 @@ end
 ---@param p_Angle number
 ---@return number
 function Utilities:NormalizeAngleRad(p_Angle)
-	if p_Angle > math.pi then
-		p_Angle = p_Angle - 2 * math.pi
-	elseif p_Angle < -math.pi then
+	-- Ensure the angle is in the range (-2π, 2π).
+	p_Angle = math.fmod(p_Angle, 2 * math.pi)
+	-- Normalise the angle to its equivalent in [-π, π).
+	if p_Angle < -math.pi then
 		p_Angle = p_Angle + 2 * math.pi
+	elseif math.pi <= p_Angle then
+		p_Angle = p_Angle - 2 * math.pi
 	end
 	return p_Angle
 end


### PR DESCRIPTION
In `Utilities:NormalizeAngleRad`, protect against angles which include multiple rotations by converting them to an equivalent angle in the interval [-π, π). Also, simplify the yaw calculation in `Bot:ShootAt`.